### PR TITLE
perf: gate eager JSON.stringify in debug calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ interface SKDeltaSubscription {
 }
 
 interface CourseComputerApp extends Application, ServerAPI {
+  // `debug` at runtime is the `debug` npm module instance; its `enabled`
+  // flag is toggled live by the SignalK Admin UI.
+  debug: ((msg: any, ...args: any[]) => void) & { enabled?: boolean }
   subscriptionmanager: {
     subscribe: (
       subscribe: SKDeltaSubscription,
@@ -215,9 +218,11 @@ module.exports = (server: CourseComputerApp): Plugin => {
           }
           u.values.forEach((v: DeltaValue) => {
             if (v.path === 'navigation.position') {
-              server.debug(
-                `navigation.position ${JSON.stringify(v.value)} => calc()`
-              )
+              if (server.debug.enabled) {
+                server.debug(
+                  `navigation.position ${JSON.stringify(v.value)} => calc()`
+                )
+              }
               srcPaths[v.path] = v.value
               calc()
             } else if (v.path === 'navigation.course.activeRoute') {
@@ -350,13 +355,17 @@ module.exports = (server: CourseComputerApp): Plugin => {
 
   // trigger course calculations
   const calc = () => {
-    server.debug(
-      `*** navigation.position *** ${JSON.stringify(
-        srcPaths['navigation.position']
-      )}`
-    )
+    if (server.debug.enabled) {
+      server.debug(
+        `*** navigation.position *** ${JSON.stringify(
+          srcPaths['navigation.position']
+        )}`
+      )
+    }
     if (srcPaths['navigation.position']) {
-      server.debug(JSON.stringify(srcPaths))
+      if (server.debug.enabled) {
+        server.debug(JSON.stringify(srcPaths))
+      }
       worker?.postMessage(srcPaths)
     } else {
       server.debug('No vessel position.....Skipping calc()')
@@ -366,7 +375,9 @@ module.exports = (server: CourseComputerApp): Plugin => {
   // send calculation results delta
   const calcResult = async (result: CourseData) => {
     server.debug(`*** calculation result ***`)
-    server.debug(JSON.stringify(result))
+    if (server.debug.enabled) {
+      server.debug(JSON.stringify(result))
+    }
     watchArrival.rangeMax = srcPaths['navigation.course.arrivalCircle'] ?? -1
     watchArrival.value = result.gc?.distance ?? -1
     watchPassedDest.value = result.passedPerpendicular ? 1 : 0


### PR DESCRIPTION
Addresses task 1 of #9.

## Summary

`JSON.stringify` inside a template literal runs unconditionally on every position tick (v.value in the delta value handler, srcPaths and result in calc/calcResult). This narrows `server.debug` in the `CourseComputerApp` interface so its `.enabled` flag is typed, and guards the four call sites whose argument actually performs work.

Static-string debug calls (`*** calculation result ***`, `*** course data delta sent***`, etc.) are left as-is: the `debug` module already short-circuits them cheaply when disabled, and guarding them adds noise for no measurable win.

## Verification

- `tsc --noEmit` clean, `prettier --check` clean.
- `vitest run` — 9/9 pass.