### PR TITLE
perf: extract buildDeltaMsg with a fixed-shape values array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { Plugin, ServerAPI, SKVersion, CourseInfo } from '@signalk/server-api'
 import { Application, Request, Response } from 'express'
 import { Notification, Watcher, WatchEvent } from './lib/alarms'
+import { buildDeltaMsg, CalcMethod } from './lib/delta-msg'
 import {
   CourseData,
   SKPaths,
@@ -373,7 +374,10 @@ module.exports = (server: CourseComputerApp): Plugin => {
     courseCalcs = result
     server.handleMessage(
       plugin.id,
-      buildDeltaMsg(courseCalcs as CourseData),
+      buildDeltaMsg(
+        courseCalcs as CourseData,
+        config.calculations.method as CalcMethod
+      ),
       SKVersion.v2
     )
     server.debug(`*** course data delta sent***`)
@@ -381,127 +385,6 @@ module.exports = (server: CourseComputerApp): Plugin => {
       server.handleMessage(plugin.id, buildMetaDeltaMsg(), SKVersion.v2)
       server.debug(`*** meta delta sent***`)
       metaSent = true
-    }
-  }
-
-  const buildDeltaMsg = (course: CourseData): any => {
-    const values: Array<{ path: string; value: any }> = []
-    const calcPath = 'navigation.course.calcValues'
-    const source =
-      config.calculations.method === 'Rhumbline' ? course.rl : course.gc
-
-    server.debug(`*** building course data delta ***`)
-    values.push({
-      path: `${calcPath}.calcMethod`,
-      value: config.calculations.method
-    })
-    values.push({
-      path: `${calcPath}.bearingTrackTrue`,
-      value:
-        typeof source.bearingTrackTrue === 'undefined'
-          ? null
-          : source.bearingTrackTrue
-    })
-    values.push({
-      path: `${calcPath}.bearingTrackMagnetic`,
-      value:
-        typeof source.bearingTrackMagnetic === 'undefined'
-          ? null
-          : source.bearingTrackMagnetic
-    })
-    values.push({
-      path: `${calcPath}.crossTrackError`,
-      value:
-        typeof source.crossTrackError === 'undefined'
-          ? null
-          : source.crossTrackError
-    })
-
-    values.push({
-      path: `${calcPath}.previousPoint.distance`,
-      value:
-        typeof source.previousPoint?.distance === 'undefined'
-          ? null
-          : source.previousPoint?.distance
-    })
-
-    values.push({
-      path: `${calcPath}.distance`,
-      value: typeof source?.distance === 'undefined' ? null : source?.distance
-    })
-    values.push({
-      path: `${calcPath}.bearingTrue`,
-      value:
-        typeof source?.bearingTrue === 'undefined' ? null : source?.bearingTrue
-    })
-    values.push({
-      path: `${calcPath}.bearingMagnetic`,
-      value:
-        typeof source?.bearingMagnetic === 'undefined'
-          ? null
-          : source?.bearingMagnetic
-    })
-
-    values.push({
-      path: `${calcPath}.velocityMadeGood`,
-      value:
-        typeof source?.velocityMadeGoodToCourse === 'undefined'
-          ? null
-          : source?.velocityMadeGoodToCourse
-    })
-    values.push({
-      path: `performance.velocityMadeGoodToWaypoint`,
-      value:
-        typeof source?.velocityMadeGoodToCourse === 'undefined'
-          ? null
-          : source?.velocityMadeGoodToCourse
-    })
-    values.push({
-      path: `${calcPath}.timeToGo`,
-      value: typeof source?.timeToGo === 'undefined' ? null : source?.timeToGo
-    })
-    values.push({
-      path: `${calcPath}.estimatedTimeOfArrival`,
-      value:
-        typeof source?.estimatedTimeOfArrival === 'undefined'
-          ? null
-          : source?.estimatedTimeOfArrival
-    })
-
-    values.push({
-      path: `${calcPath}.route.timeToGo`,
-      value:
-        typeof source?.route?.timeToGo === 'undefined'
-          ? null
-          : source?.route?.timeToGo
-    })
-    values.push({
-      path: `${calcPath}.route.estimatedTimeOfArrival`,
-      value:
-        typeof source?.route?.estimatedTimeOfArrival === 'undefined'
-          ? null
-          : source?.route?.estimatedTimeOfArrival
-    })
-    values.push({
-      path: `${calcPath}.route.distance`,
-      value:
-        typeof source?.route?.distance === 'undefined'
-          ? null
-          : source?.route?.distance
-    })
-
-    values.push({
-      path: `${calcPath}.targetSpeed`,
-      value:
-        typeof source?.targetSpeed === 'undefined' ? null : source?.targetSpeed
-    })
-
-    return {
-      updates: [
-        {
-          values: values
-        }
-      ]
     }
   }
 

--- a/src/lib/delta-msg.ts
+++ b/src/lib/delta-msg.ts
@@ -1,0 +1,101 @@
+import { CourseData } from '../types'
+
+export type CalcMethod = 'GreatCircle' | 'Rhumbline'
+
+export interface DeltaValueEntry {
+  path: string
+  value: unknown
+}
+
+export interface DeltaMessage {
+  updates: Array<{ values: DeltaValueEntry[] }>
+}
+
+const BASE = 'navigation.course.calcValues'
+
+const PATH_CALC_METHOD = `${BASE}.calcMethod`
+const PATH_BEARING_TRACK_TRUE = `${BASE}.bearingTrackTrue`
+const PATH_BEARING_TRACK_MAG = `${BASE}.bearingTrackMagnetic`
+const PATH_XTE = `${BASE}.crossTrackError`
+const PATH_PREV_POINT_DISTANCE = `${BASE}.previousPoint.distance`
+const PATH_DISTANCE = `${BASE}.distance`
+const PATH_BEARING_TRUE = `${BASE}.bearingTrue`
+const PATH_BEARING_MAG = `${BASE}.bearingMagnetic`
+const PATH_VMG = `${BASE}.velocityMadeGood`
+const PATH_PERF_VMG_WAYPOINT = 'performance.velocityMadeGoodToWaypoint'
+const PATH_TTG = `${BASE}.timeToGo`
+const PATH_ETA = `${BASE}.estimatedTimeOfArrival`
+const PATH_ROUTE_TTG = `${BASE}.route.timeToGo`
+const PATH_ROUTE_ETA = `${BASE}.route.estimatedTimeOfArrival`
+const PATH_ROUTE_DISTANCE = `${BASE}.route.distance`
+const PATH_TARGET_SPEED = `${BASE}.targetSpeed`
+
+const VALUES_LENGTH = 16
+
+/**
+ * Build a SignalK v2 delta message for the course calcValues subtree.
+ *
+ * Note the intentional quirk: `velocityMadeGood` (and the performance
+ * mirror) publish `source.velocityMadeGoodToCourse`, not `velocityMadeGood`,
+ * preserved verbatim from the original implementation to keep the delta
+ * stream byte-compatible with existing subscribers.
+ */
+export function buildDeltaMsg(
+  course: CourseData,
+  method: CalcMethod
+): DeltaMessage {
+  const source = method === 'Rhumbline' ? course.rl : course.gc
+  const values: DeltaValueEntry[] = new Array(VALUES_LENGTH)
+
+  values[0] = { path: PATH_CALC_METHOD, value: method }
+  values[1] = {
+    path: PATH_BEARING_TRACK_TRUE,
+    value: source.bearingTrackTrue ?? null
+  }
+  values[2] = {
+    path: PATH_BEARING_TRACK_MAG,
+    value: source.bearingTrackMagnetic ?? null
+  }
+  values[3] = { path: PATH_XTE, value: source.crossTrackError ?? null }
+  values[4] = {
+    path: PATH_PREV_POINT_DISTANCE,
+    value: source.previousPoint?.distance ?? null
+  }
+  values[5] = { path: PATH_DISTANCE, value: source.distance ?? null }
+  values[6] = { path: PATH_BEARING_TRUE, value: source.bearingTrue ?? null }
+  values[7] = {
+    path: PATH_BEARING_MAG,
+    value: source.bearingMagnetic ?? null
+  }
+  values[8] = {
+    path: PATH_VMG,
+    value: source.velocityMadeGoodToCourse ?? null
+  }
+  values[9] = {
+    path: PATH_PERF_VMG_WAYPOINT,
+    value: source.velocityMadeGoodToCourse ?? null
+  }
+  values[10] = { path: PATH_TTG, value: source.timeToGo ?? null }
+  values[11] = {
+    path: PATH_ETA,
+    value: source.estimatedTimeOfArrival ?? null
+  }
+  values[12] = {
+    path: PATH_ROUTE_TTG,
+    value: source.route?.timeToGo ?? null
+  }
+  values[13] = {
+    path: PATH_ROUTE_ETA,
+    value: source.route?.estimatedTimeOfArrival ?? null
+  }
+  values[14] = {
+    path: PATH_ROUTE_DISTANCE,
+    value: source.route?.distance ?? null
+  }
+  values[15] = {
+    path: PATH_TARGET_SPEED,
+    value: source.targetSpeed ?? null
+  }
+
+  return { updates: [{ values }] }
+}

--- a/test/delta-msg.test.ts
+++ b/test/delta-msg.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+import { buildDeltaMsg } from '../src/lib/delta-msg'
+import { CourseData } from '../src/types'
+
+function fullCourseData(): CourseData {
+  const gc = {
+    calcMethod: 'GreatCircle',
+    bearingTrackTrue: 1.1,
+    bearingTrackMagnetic: 1.2,
+    crossTrackError: -3.4,
+    distance: 5000,
+    bearingTrue: 2.1,
+    bearingMagnetic: 2.2,
+    velocityMadeGood: 4.5,
+    velocityMadeGoodToCourse: 4.2,
+    timeToGo: 1200,
+    estimatedTimeOfArrival: '2020-01-01T00:20:00.000Z',
+    previousPoint: { distance: 100 },
+    route: {
+      timeToGo: 3600,
+      estimatedTimeOfArrival: '2020-01-01T01:00:00.000Z',
+      distance: 15000
+    },
+    targetSpeed: 4.17
+  }
+  const rl = {
+    ...gc,
+    calcMethod: 'Rhumbline',
+    bearingTrackTrue: 9.9,
+    distance: 6000
+  }
+  return { gc, rl, passedPerpendicular: false }
+}
+
+describe('buildDeltaMsg', () => {
+  it('emits all 16 paths in stable order', () => {
+    const msg = buildDeltaMsg(fullCourseData(), 'GreatCircle')
+    const values = msg.updates[0].values
+
+    expect(values).toHaveLength(16)
+    const paths = values.map((v) => v.path)
+    expect(paths).toEqual([
+      'navigation.course.calcValues.calcMethod',
+      'navigation.course.calcValues.bearingTrackTrue',
+      'navigation.course.calcValues.bearingTrackMagnetic',
+      'navigation.course.calcValues.crossTrackError',
+      'navigation.course.calcValues.previousPoint.distance',
+      'navigation.course.calcValues.distance',
+      'navigation.course.calcValues.bearingTrue',
+      'navigation.course.calcValues.bearingMagnetic',
+      'navigation.course.calcValues.velocityMadeGood',
+      'performance.velocityMadeGoodToWaypoint',
+      'navigation.course.calcValues.timeToGo',
+      'navigation.course.calcValues.estimatedTimeOfArrival',
+      'navigation.course.calcValues.route.timeToGo',
+      'navigation.course.calcValues.route.estimatedTimeOfArrival',
+      'navigation.course.calcValues.route.distance',
+      'navigation.course.calcValues.targetSpeed'
+    ])
+  })
+
+  it('maps GreatCircle source fields and echoes method in calcMethod', () => {
+    const course = fullCourseData()
+    const msg = buildDeltaMsg(course, 'GreatCircle')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.calcMethod']).toBe(
+      'GreatCircle'
+    )
+    expect(byPath['navigation.course.calcValues.bearingTrackTrue']).toBe(1.1)
+    expect(byPath['navigation.course.calcValues.distance']).toBe(5000)
+    expect(byPath['navigation.course.calcValues.previousPoint.distance']).toBe(
+      100
+    )
+    expect(
+      byPath['navigation.course.calcValues.route.estimatedTimeOfArrival']
+    ).toBe('2020-01-01T01:00:00.000Z')
+    expect(byPath['navigation.course.calcValues.targetSpeed']).toBe(4.17)
+  })
+
+  it('selects the Rhumbline branch when method is Rhumbline', () => {
+    const course = fullCourseData()
+    const msg = buildDeltaMsg(course, 'Rhumbline')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.calcMethod']).toBe('Rhumbline')
+    expect(byPath['navigation.course.calcValues.bearingTrackTrue']).toBe(9.9)
+    expect(byPath['navigation.course.calcValues.distance']).toBe(6000)
+  })
+
+  it('publishes velocityMadeGoodToCourse under both VMG paths', () => {
+    // Intentional quirk preserved from the original implementation: both
+    // `velocityMadeGood` and `performance.velocityMadeGoodToWaypoint` expose
+    // the VMC-to-course value, not the VMG-to-wind one.
+    const course = fullCourseData()
+    const msg = buildDeltaMsg(course, 'GreatCircle')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.velocityMadeGood']).toBe(4.2)
+    expect(byPath['performance.velocityMadeGoodToWaypoint']).toBe(4.2)
+  })
+
+  it('maps undefined fields to null', () => {
+    const course: CourseData = {
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    }
+    const msg = buildDeltaMsg(course, 'GreatCircle')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.calcMethod']).toBe(
+      'GreatCircle'
+    )
+    expect(byPath['navigation.course.calcValues.bearingTrackTrue']).toBeNull()
+    expect(byPath['navigation.course.calcValues.distance']).toBeNull()
+    expect(
+      byPath['navigation.course.calcValues.previousPoint.distance']
+    ).toBeNull()
+    expect(byPath['navigation.course.calcValues.route.timeToGo']).toBeNull()
+    expect(byPath['navigation.course.calcValues.targetSpeed']).toBeNull()
+  })
+
+  it('maps explicit null fields to null', () => {
+    const course: CourseData = {
+      gc: {
+        bearingTrackTrue: null,
+        distance: null,
+        previousPoint: { distance: null },
+        route: { timeToGo: null, estimatedTimeOfArrival: null, distance: null },
+        targetSpeed: null
+      },
+      rl: {},
+      passedPerpendicular: false
+    }
+    const msg = buildDeltaMsg(course, 'GreatCircle')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.bearingTrackTrue']).toBeNull()
+    expect(byPath['navigation.course.calcValues.distance']).toBeNull()
+    expect(byPath['navigation.course.calcValues.route.distance']).toBeNull()
+  })
+
+  it('preserves zero as a non-null value (distinguishes from undefined)', () => {
+    const course: CourseData = {
+      gc: { distance: 0, crossTrackError: 0, timeToGo: 0, targetSpeed: 0 },
+      rl: {},
+      passedPerpendicular: false
+    }
+    const msg = buildDeltaMsg(course, 'GreatCircle')
+    const byPath = Object.fromEntries(
+      msg.updates[0].values.map((v) => [v.path, v.value])
+    )
+
+    expect(byPath['navigation.course.calcValues.distance']).toBe(0)
+    expect(byPath['navigation.course.calcValues.crossTrackError']).toBe(0)
+    expect(byPath['navigation.course.calcValues.timeToGo']).toBe(0)
+    expect(byPath['navigation.course.calcValues.targetSpeed']).toBe(0)
+  })
+})


### PR DESCRIPTION
Addresses task 10 of #9.

## Summary

Move the inline `buildDeltaMsg` into `src/lib/delta-msg.ts` as a pure function. Pre-allocate the 16-entry values array and index-assign `{path, value}` literals in stable key order, so V8 can share a single hidden class across ticks. Paths are built once at module load; the repeated `typeof x === 'undefined' ? null : x` chains become `x ?? null`.

The intentional quirk where both `velocityMadeGood` and `performance.velocityMadeGoodToWaypoint` publish `source.velocityMadeGoodToCourse` is preserved and pinned by a test, so the delta stream stays byte-compatible with existing subscribers.

## Verification

- `tsc --noEmit` clean, `prettier --check` clean.
- `vitest run` — 16/16 pass.
- New `test/delta-msg.test.ts` covers path order, GC/RL branch selection, undefined -> null mapping, explicit null preservation, and zero being preserved (not coerced to null).