### PR TITLE
ci: add release_on_tag and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          registry-url: 'https://registry.npmjs.org'
+      # The package.json "prepublishOnly" script runs `tsc`, so the build
+      # happens implicitly during `npm publish`.
+      - run: npm install
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -1,0 +1,28 @@
+name: 'Release on tag'
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: ${{ steps.github_release.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Adds the two-step release/publish flow used by the sibling plugin repos (\`signalk-derived-data\`, \`nmea0183-signalk\`, \`signalk-to-nmea0183\`, ...) so \`@signalk/course-provider\` can be released from a pushed tag instead of manually.

## Summary
- \`.github/workflows/release_on_tag.yml\` \u2014 on any pushed tag, builds a changelog from merged PRs and creates a GitHub Release.
- \`.github/workflows/publish.yml\` \u2014 on \`release: created\`, runs \`npm install && npm publish --access public\` on Node 22.x with OIDC (\`id-token: write\`) and \`NODE_AUTH_TOKEN\`. The package.json \`prepublishOnly: tsc\` runs automatically during \`npm publish\`, so no explicit build step is needed.

I deliberately left out the \`steps.vars.outputs.tag\` beta branch that exists in some sibling publish.yml files \u2014 it's dead code there (the \`vars\` step is never defined) and this package does not publish betas.

## Required repository secrets
- \`NPM_TOKEN\`
- \`RELEASE_PAT\`

## Test plan
- [x] YAML syntax validated locally
- [ ] Maintainer confirms \`NPM_TOKEN\` and \`RELEASE_PAT\` are configured on the repo
- [ ] First tag push after merge produces a GitHub Release and an npm publish