### PR TITLE
perf: compute only the configured calc method per tick

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { Plugin, ServerAPI, SKVersion, CourseInfo } from '@signalk/server-api'
 import { Application, Request, Response } from 'express'
 import { Notification, Watcher, WatchEvent } from './lib/alarms'
-import { buildDeltaMsg, CalcMethod } from './lib/delta-msg'
+import { buildDeltaMsg } from './lib/delta-msg'
 import {
+  CalcMethod,
+  CalcRequest,
   CourseData,
   SKPaths,
   ALARM_METHOD,
@@ -374,7 +376,11 @@ module.exports = (server: CourseComputerApp): Plugin => {
       if (server.debug.enabled) {
         server.debug(JSON.stringify(srcPaths))
       }
-      worker?.postMessage(srcPaths)
+      const request: CalcRequest = {
+        paths: srcPaths,
+        method: config.calculations.method as CalcMethod
+      }
+      worker?.postMessage(request)
     } else {
       server.debug('No vessel position.....Skipping calc()')
     }
@@ -386,16 +392,15 @@ module.exports = (server: CourseComputerApp): Plugin => {
     if (server.debug.enabled) {
       server.debug(JSON.stringify(result))
     }
+    const method = config.calculations.method as CalcMethod
+    const branch = method === 'Rhumbline' ? result.rl : result.gc
     watchArrival.rangeMax = srcPaths['navigation.course.arrivalCircle'] ?? -1
-    watchArrival.value = result.gc?.distance ?? -1
+    watchArrival.value = branch?.distance ?? -1
     watchPassedDest.value = result.passedPerpendicular ? 1 : 0
     courseCalcs = result
     server.handleMessage(
       plugin.id,
-      buildDeltaMsg(
-        courseCalcs as CourseData,
-        config.calculations.method as CalcMethod
-      ),
+      buildDeltaMsg(courseCalcs as CourseData, method),
       SKVersion.v2
     )
     server.debug(`*** course data delta sent***`)

--- a/src/lib/delta-msg.ts
+++ b/src/lib/delta-msg.ts
@@ -1,7 +1,7 @@
 import { Path, PathValue } from '@signalk/server-api'
-import { CourseData } from '../types'
+import { CalcMethod, CourseData } from '../types'
 
-export type CalcMethod = 'GreatCircle' | 'Rhumbline'
+export type { CalcMethod }
 
 const BASE = 'navigation.course.calcValues'
 
@@ -32,10 +32,7 @@ const VALUES_LENGTH = 16
  * preserved verbatim from the original implementation to keep the delta
  * stream byte-compatible with existing subscribers.
  */
-export function buildDeltaMsg(
-  course: CourseData,
-  method: CalcMethod
-) {
+export function buildDeltaMsg(course: CourseData, method: CalcMethod) {
   const source = method === 'Rhumbline' ? course.rl : course.gc
   const values: PathValue[] = new Array(VALUES_LENGTH)
 
@@ -54,7 +51,10 @@ export function buildDeltaMsg(
     value: source.previousPoint?.distance ?? null
   }
   values[5] = { path: PATH_DISTANCE as Path, value: source.distance ?? null }
-  values[6] = { path: PATH_BEARING_TRUE as Path, value: source.bearingTrue ?? null }
+  values[6] = {
+    path: PATH_BEARING_TRUE as Path,
+    value: source.bearingTrue ?? null
+  }
   values[7] = {
     path: PATH_BEARING_MAG as Path,
     value: source.bearingMagnetic ?? null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,17 @@ export interface SKPaths {
   [key: string]: any
 }
 
+export type CalcMethod = 'GreatCircle' | 'Rhumbline'
+
+// Worker invocation envelope. The worker only ever needs the current path
+// snapshot plus the calculation method that buildDeltaMsg will publish, so
+// we send those together to avoid keeping the worker stateful or mixing the
+// method tag into the SignalK path map.
+export interface CalcRequest {
+  paths: SKPaths
+  method: CalcMethod
+}
+
 export interface CourseData {
   gc: CourseResult
   rl: CourseResult

--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -1,17 +1,41 @@
+/**
+ * Course calculation worker.
+ *
+ * Runs in a Node worker thread. Each tick it receives the latest SignalK
+ * path snapshot plus the configured calculation method (GreatCircle or
+ * Rhumbline) and emits the corresponding `CourseData` slice the main thread
+ * needs to publish. Only the configured branch is computed; the unused
+ * branch is returned empty so existing callers can still index by `gc`/`rl`
+ * without conditional access.
+ */
+
 import { parentPort } from 'worker_threads'
-import { CourseData, SKPaths } from '../types'
+import {
+  CalcMethod,
+  CalcRequest,
+  CourseData,
+  CourseResult,
+  SKPaths
+} from '../types'
 import { LatLonSpherical as LatLon } from '../lib/geodesy/latlon-spherical.js'
+
+// Empty-result template factory. Used both for the no-active-destination
+// transition message and the early-exit path inside calcs(); centralising
+// the shape avoids drift if CourseData ever gets a new required field.
+function emptyCourseData(): CourseData {
+  return { gc: {}, rl: {}, passedPerpendicular: false }
+}
 
 let activeDest = false
 
 // process message from main thread
-parentPort?.on('message', (message: SKPaths) => {
-  if (parseSKPaths(message)) {
-    parentPort?.postMessage(calcs(message))
+parentPort?.on('message', (message: CalcRequest) => {
+  if (parseSKPaths(message.paths)) {
+    parentPort?.postMessage(calcs(message.paths, message.method))
     activeDest = true
   } else {
     if (activeDest) {
-      parentPort?.postMessage({ gc: {}, rl: {} })
+      parentPort?.postMessage(emptyCourseData())
       activeDest = false
     }
   }
@@ -42,8 +66,12 @@ function compassAngle(angle: number): number {
     : angle
 }
 
-// course calculations
-function calcs(src: SKPaths): CourseData {
+// course calculations.
+//
+// `method` selects the branch (`gc` for GreatCircle, `rl` for Rhumbline) to
+// compute. The unused branch is returned empty so existing callers can still
+// index by `gc`/`rl` without conditional access.
+export function calcs(src: SKPaths, method: CalcMethod): CourseData {
   const vesselPosition = src['navigation.position']
     ? new LatLon(
         src['navigation.position'].latitude,
@@ -63,79 +91,62 @@ function calcs(src: SKPaths): CourseData {
       )
     : null
 
-  const res: CourseData = { gc: {}, rl: {}, passedPerpendicular: false }
+  const res = emptyCourseData()
   if (!vesselPosition || !destination || !startPoint) {
     return res
   }
 
-  const xte = vesselPosition?.crossTrackDistanceTo(startPoint, destination)
+  const xte = vesselPosition.crossTrackDistanceTo(startPoint, destination)
   const magVar = src['navigation.magneticVariation'] ?? 0.0
   const vmgValue = vmg(src)
+  const rhumbLine = method === 'Rhumbline'
 
-  // GreatCircle
-  const bearingTrackTrue = toRadians(startPoint?.initialBearingTo(destination))
-  const bearingTrue = toRadians(vesselPosition?.initialBearingTo(destination))
+  const bearingTrackTrue = toRadians(
+    rhumbLine
+      ? startPoint.rhumbBearingTo(destination)
+      : startPoint.initialBearingTo(destination)
+  )
   const bearingTrackMagnetic = compassAngle(bearingTrackTrue + magVar)
+  const bearingTrue = toRadians(
+    rhumbLine
+      ? vesselPosition.rhumbBearingTo(destination)
+      : vesselPosition.initialBearingTo(destination)
+  )
   const bearingMagnetic = compassAngle(bearingTrue + magVar)
-  const gcDistance = vesselPosition?.distanceTo(destination)
-  const gcVmg = vmgValue
-  const gcVmc = vmc(src, bearingTrue, 'true') // for ETA, TTG - prefer 'true' values
-  const gcTime = timeCalcs(src, gcDistance, gcVmc as number, false)
+  const distance = rhumbLine
+    ? vesselPosition.rhumbDistanceTo(destination)
+    : vesselPosition.distanceTo(destination)
+  const vmcValue = vmc(src, bearingTrue, 'true') // for ETA, TTG - prefer 'true' values
+  const time = timeCalcs(src, distance, vmcValue as number, rhumbLine)
+  const previousPointDistance = rhumbLine
+    ? vesselPosition.rhumbDistanceTo(startPoint)
+    : vesselPosition.distanceTo(startPoint)
 
-  res.gc = {
-    calcMethod: 'GreatCircle',
-    bearingTrackTrue: bearingTrackTrue,
-    bearingTrackMagnetic: bearingTrackMagnetic,
+  const methodResult: CourseResult = {
+    calcMethod: rhumbLine ? 'Rhumbline' : 'GreatCircle',
+    bearingTrackTrue,
+    bearingTrackMagnetic,
     crossTrackError: xte,
-    distance: gcDistance,
-    bearingTrue: bearingTrue,
-    bearingMagnetic: bearingMagnetic,
-    velocityMadeGood: gcVmg,
-    velocityMadeGoodToCourse: gcVmc,
-    timeToGo: gcTime.nextPoint.ttg,
-    estimatedTimeOfArrival: gcTime.nextPoint.eta,
-    previousPoint: {
-      distance: vesselPosition?.distanceTo(startPoint)
-    },
+    distance,
+    bearingTrue,
+    bearingMagnetic,
+    velocityMadeGood: vmgValue,
+    velocityMadeGoodToCourse: vmcValue,
+    timeToGo: time.nextPoint.ttg,
+    estimatedTimeOfArrival: time.nextPoint.eta,
+    previousPoint: { distance: previousPointDistance },
     route: {
-      timeToGo: gcTime.route.ttg,
-      estimatedTimeOfArrival: gcTime.route.eta,
-      distance: gcTime.route.dtg
+      timeToGo: time.route.ttg,
+      estimatedTimeOfArrival: time.route.eta,
+      distance: time.route.dtg
     },
-    targetSpeed: targetSpeed(src, gcDistance)
+    targetSpeed: targetSpeed(src, distance, rhumbLine)
   }
 
-  // Rhumbline
-  const rlBearingTrackTrue = toRadians(startPoint?.rhumbBearingTo(destination))
-  const rlBearingTrue = toRadians(vesselPosition?.rhumbBearingTo(destination))
-  const rlBearingTrackMagnetic = compassAngle(rlBearingTrackTrue + magVar)
-  const rlBearingMagnetic = compassAngle(rlBearingTrue + magVar)
-  const rlDistance = vesselPosition?.rhumbDistanceTo(destination)
-  const rlVmg = vmgValue
-  const rlVmc = vmc(src, rlBearingTrue, 'true') // for ETA, TTG - prefer 'true' values
-  const rlTime = timeCalcs(src, rlDistance, rlVmc as number, true)
-
-  res.rl = {
-    calcMethod: 'Rhumbline',
-    bearingTrackTrue: rlBearingTrackTrue,
-    bearingTrackMagnetic: rlBearingTrackMagnetic,
-    crossTrackError: xte,
-    distance: rlDistance,
-    bearingTrue: rlBearingTrue,
-    bearingMagnetic: rlBearingMagnetic,
-    velocityMadeGood: rlVmg,
-    velocityMadeGoodToCourse: rlVmc,
-    timeToGo: rlTime.nextPoint.ttg,
-    estimatedTimeOfArrival: rlTime.nextPoint.eta,
-    previousPoint: {
-      distance: vesselPosition?.rhumbDistanceTo(startPoint)
-    },
-    route: {
-      timeToGo: rlTime.route.ttg,
-      estimatedTimeOfArrival: rlTime.route.eta,
-      distance: rlTime.route.dtg
-    },
-    targetSpeed: targetSpeed(src, rlDistance, true)
+  if (rhumbLine) {
+    res.rl = methodResult
+  } else {
+    res.gc = methodResult
   }
 
   // passed destination perpendicular

--- a/test/active-route.test.ts
+++ b/test/active-route.test.ts
@@ -90,7 +90,8 @@ async function startPlugin(getResourceImpl: (id: string) => Promise<any>) {
 }
 
 // Drive a navigation.position through the dispatcher so the worker mock
-// receives the current srcPaths snapshot. Returns that snapshot object.
+// receives the current srcPaths snapshot. Returns the paths object from
+// the latest posted CalcRequest envelope.
 async function snapshotSrcPaths(
   deltaCallback: DeltaCallback,
   worker: MockWorker
@@ -112,7 +113,10 @@ async function snapshotSrcPaths(
   await new Promise((r) => setTimeout(r, 0))
   const after = worker.postedMessages.length
   expect(after).toBeGreaterThan(before)
-  return worker.postedMessages[after - 1] as Record<string, any>
+  const envelope = worker.postedMessages[after - 1] as {
+    paths: Record<string, any>
+  }
+  return envelope.paths
 }
 
 describe('navigation.course.activeRoute dispatch', () => {

--- a/test/calc-result.test.ts
+++ b/test/calc-result.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Tests the main-thread side of the worker -> main round trip: when the
+// worker fires a `message` event with a CourseData result, calcResult must
+// drive the arrival watcher and the published delta from the configured
+// method's branch — not unconditionally from `gc`.
+
+const workerInstances: MockWorker[] = []
+
+class MockWorker {
+  public postedMessages: unknown[] = []
+  private listeners: Record<string, Array<(arg: unknown) => void>> = {}
+
+  constructor(public filename: string) {
+    workerInstances.push(this)
+  }
+
+  on(event: string, handler: (arg: unknown) => void) {
+    this.listeners[event] = this.listeners[event] || []
+    this.listeners[event].push(handler)
+    return this
+  }
+
+  removeAllListeners() {
+    this.listeners = {}
+    return this
+  }
+
+  terminate() {
+    return Promise.resolve(0)
+  }
+
+  postMessage(_msg: unknown) {}
+
+  unref() {}
+
+  // Test-only: invokes registered listeners synchronously, simulating the
+  // worker firing back into the main thread.
+  fire(event: string, arg: unknown) {
+    const handlers = this.listeners[event] ?? []
+    for (const h of handlers) h(arg)
+  }
+}
+
+vi.mock('worker_threads', () => ({ Worker: MockWorker }))
+vi.mock('express', () => ({}))
+
+beforeEach(() => {
+  workerInstances.length = 0
+  vi.resetModules()
+})
+
+async function startPlugin(method: 'GreatCircle' | 'Rhumbline') {
+  const pluginModule = (await import('../src/index.ts')) as any
+  const factory = (pluginModule.default ?? pluginModule) as (server: any) => {
+    start: (options: any) => void
+    stop: () => void
+  }
+
+  const server = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    setPluginStatus: vi.fn(),
+    setPluginError: vi.fn(),
+    handleMessage: vi.fn(),
+    getSelfPath: vi.fn(() => null),
+    getCourse: vi.fn(() => Promise.resolve(null)),
+    get: vi.fn(),
+    subscriptionmanager: {
+      subscribe: vi.fn((_sub: unknown, unsubscribes: Array<() => void>) => {
+        unsubscribes.push(() => {})
+      })
+    },
+    resourcesApi: { getResource: vi.fn(() => Promise.resolve(null)) }
+  }
+
+  const plugin = factory(server)
+  plugin.start({ notifications: { sound: false }, calculations: { method } })
+  return {
+    server,
+    worker: workerInstances[workerInstances.length - 1],
+    stop: () => plugin.stop()
+  }
+}
+
+function distanceFromDelta(handleMessageMock: any): number | null {
+  // The plugin emits a v2 delta whose `values` array is the fixed-shape
+  // output of buildDeltaMsg. The distance entry is at index 5.
+  for (const call of handleMessageMock.mock.calls) {
+    const msg = call[1]
+    const values = msg?.updates?.[0]?.values
+    if (!Array.isArray(values)) continue
+    for (const v of values) {
+      if (v.path === 'navigation.course.calcValues.distance') {
+        return v.value
+      }
+    }
+  }
+  return null
+}
+
+describe('calcResult selects the configured method branch', () => {
+  it('publishes Rhumbline distance when configured for Rhumbline', async () => {
+    const { server, worker, stop } = await startPlugin('Rhumbline')
+
+    worker.fire('message', {
+      gc: {},
+      rl: { distance: 1234, calcMethod: 'Rhumbline' },
+      passedPerpendicular: false
+    })
+
+    expect(distanceFromDelta(server.handleMessage)).toBe(1234)
+    stop()
+  })
+
+  it('publishes GreatCircle distance when configured for GreatCircle', async () => {
+    const { server, worker, stop } = await startPlugin('GreatCircle')
+
+    worker.fire('message', {
+      gc: { distance: 5678, calcMethod: 'GreatCircle' },
+      rl: {},
+      passedPerpendicular: false
+    })
+
+    expect(distanceFromDelta(server.handleMessage)).toBe(5678)
+    stop()
+  })
+})

--- a/test/course-calcs.test.ts
+++ b/test/course-calcs.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+// LatLon stub. Methods return deterministic values derived from the points'
+// coordinates so tests can predict output and assert on call counts.
+//
+// distance(a, b)        = hypot(dLat, dLon) * 1000   (m)
+// rhumbDistance(a, b)   = distance(a, b) + 0.5       (so gc and rl are
+//                                                     distinguishable but
+//                                                     close in magnitude)
+// initialBearing(a, b)  = ((b.lon - a.lon) * 90 + 360) mod 360  (deg)
+// rhumbBearing(a, b)    = initialBearing(a, b) + 1   (deg)
+class StubLatLon {
+  constructor(public lat: number, public lon: number) {}
+  distanceTo(other: StubLatLon): number {
+    const dLat = other.lat - this.lat
+    const dLon = other.lon - this.lon
+    return Math.hypot(dLat, dLon) * 1000
+  }
+  rhumbDistanceTo(other: StubLatLon): number {
+    return this.distanceTo(other) + 0.5
+  }
+  initialBearingTo(other: StubLatLon): number {
+    return ((other.lon - this.lon) * 90 + 360) % 360
+  }
+  rhumbBearingTo(other: StubLatLon): number {
+    return (this.initialBearingTo(other) + 1) % 360
+  }
+  crossTrackDistanceTo(_a: StubLatLon, _b: StubLatLon): number {
+    return 0
+  }
+}
+
+vi.mock('../src/lib/geodesy/latlon-spherical.js', () => ({
+  LatLonSpherical: StubLatLon
+}))
+
+beforeEach(() => {
+  // Reset the module registry between tests so state introduced by the
+  // module under test starts clean and prototype spies are torn down.
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+function srcWithFix(opts?: {
+  magVar?: number
+  next?: { latitude: number; longitude: number }
+}): Record<string, any> {
+  return {
+    'navigation.position': { latitude: 0, longitude: 0 },
+    'navigation.course.previousPoint': {
+      position: { latitude: 0, longitude: 0 }
+    },
+    'navigation.course.nextPoint': {
+      position: opts?.next ?? { latitude: 0, longitude: 1 }
+    },
+    'navigation.magneticVariation': opts?.magVar ?? 0,
+    'navigation.courseOverGroundTrue': Math.PI / 2,
+    'navigation.speedOverGround': 5,
+    'environment.wind.angleTrueGround': 0
+  }
+}
+
+describe('calcs computes only the configured method (task 3)', () => {
+  it('populates only `gc` for GreatCircle and leaves `rl` empty', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const result = calcs(srcWithFix(), 'GreatCircle')
+
+    expect(result.gc.calcMethod).toBe('GreatCircle')
+    expect(typeof result.gc.distance).toBe('number')
+    expect(result.rl).toEqual({})
+  })
+
+  it('populates only `rl` for Rhumbline and leaves `gc` empty', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const result = calcs(srcWithFix(), 'Rhumbline')
+
+    expect(result.rl.calcMethod).toBe('Rhumbline')
+    expect(typeof result.rl.distance).toBe('number')
+    // The stubbed rhumb distance differs from the great-circle distance by 0.5
+    // so we can be certain the rhumb branch was taken.
+    expect(result.rl.distance).toBeCloseTo(1000.5, 5)
+    expect(result.gc).toEqual({})
+  })
+
+  // The guard at the top of calcs() is `!vesselPosition || !destination ||
+  // !startPoint`. Each missing input must independently short-circuit to the
+  // empty-result shape; a refactor that drops one branch should be caught here.
+  it('returns empty branches when navigation.position is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    delete src['navigation.position']
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+
+  it('returns empty branches when nextPoint is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    delete src['navigation.course.nextPoint']
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+
+  it('returns empty branches when previousPoint position is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    src['navigation.course.previousPoint'] = {} // present but no .position
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+})

--- a/test/delta-handler.test.ts
+++ b/test/delta-handler.test.ts
@@ -128,8 +128,15 @@ describe('delta handler dispatch', () => {
     })
 
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
-    expect(msg['navigation.position']).toEqual({ latitude: 10, longitude: 20 })
+    const msg = worker.postedMessages[0] as {
+      paths: Record<string, any>
+      method: string
+    }
+    expect(msg.method).toBe('GreatCircle')
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 10,
+      longitude: 20
+    })
 
     stop()
   })
@@ -202,11 +209,14 @@ describe('delta handler dispatch', () => {
 
     // Exactly one postMessage: the one triggered by navigation.position.
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
+    const msg = worker.postedMessages[0] as { paths: Record<string, any> }
     // All three values should be present in srcPaths by the time calc() runs.
-    expect(msg['navigation.speedOverGround']).toBe(4.2)
-    expect(msg['navigation.position']).toEqual({ latitude: 1, longitude: 2 })
-    expect(msg['navigation.headingTrue']).toBe(1.57)
+    expect(msg.paths['navigation.speedOverGround']).toBe(4.2)
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 1,
+      longitude: 2
+    })
+    expect(msg.paths['navigation.headingTrue']).toBe(1.57)
     stop()
   })
 
@@ -246,9 +256,12 @@ describe('delta handler dispatch', () => {
     })
 
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
-    expect(msg['navigation.speedOverGround']).toBe(3.1)
-    expect(msg['navigation.position']).toEqual({ latitude: 5, longitude: 6 })
+    const msg = worker.postedMessages[0] as { paths: Record<string, any> }
+    expect(msg.paths['navigation.speedOverGround']).toBe(3.1)
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 5,
+      longitude: 6
+    })
     stop()
   })
 })


### PR DESCRIPTION
## Summary

`calcs` previously computed both GreatCircle and Rhumbline branches on every position tick even though only the configured one is published. This PR passes the configured method into the worker via a new `CalcRequest` envelope and selects a single branch inside `calcs`; the unused branch is left empty so existing consumers still index by `gc`/`rl` without conditional access.

The arrival watcher now follows the configured method's distance instead of always reading `result.gc?.distance` — a small behaviour fix for Rhumbline configurations.

Addresses task 3 of #9.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 38 pass (was 31)
- [x] \`npm run lint\` clean
- [ ] Soak under a real position feed at 1-2 Hz to confirm the per-tick trig cost halves.