### PR TITLE
perf: cache routeRemaining and reuse the LatLon cursor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
 import { Plugin, ServerAPI, SKVersion, CourseInfo } from '@signalk/server-api'
 import { Application, Request, Response } from 'express'
 import { Notification, Watcher, WatchEvent } from './lib/alarms'
-import { buildDeltaMsg, CalcMethod } from './lib/delta-msg'
+import { buildDeltaMsg } from './lib/delta-msg'
 import {
+  CalcMethod,
+  CalcRequest,
   CourseData,
   SKPaths,
   ALARM_METHOD,
@@ -374,7 +376,11 @@ module.exports = (server: CourseComputerApp): Plugin => {
       if (server.debug.enabled) {
         server.debug(JSON.stringify(srcPaths))
       }
-      worker?.postMessage(srcPaths)
+      const request: CalcRequest = {
+        paths: srcPaths,
+        method: config.calculations.method as CalcMethod
+      }
+      worker?.postMessage(request)
     } else {
       server.debug('No vessel position.....Skipping calc()')
     }
@@ -386,16 +392,15 @@ module.exports = (server: CourseComputerApp): Plugin => {
     if (server.debug.enabled) {
       server.debug(JSON.stringify(result))
     }
+    const method = config.calculations.method as CalcMethod
+    const branch = method === 'Rhumbline' ? result.rl : result.gc
     watchArrival.rangeMax = srcPaths['navigation.course.arrivalCircle'] ?? -1
-    watchArrival.value = result.gc?.distance ?? -1
+    watchArrival.value = branch?.distance ?? -1
     watchPassedDest.value = result.passedPerpendicular ? 1 : 0
     courseCalcs = result
     server.handleMessage(
       plugin.id,
-      buildDeltaMsg(
-        courseCalcs as CourseData,
-        config.calculations.method as CalcMethod
-      ),
+      buildDeltaMsg(courseCalcs as CourseData, method),
       SKVersion.v2
     )
     server.debug(`*** course data delta sent***`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,12 @@ module.exports = (server: CourseComputerApp): Plugin => {
   let courseCalcs: CourseData
   let activeRouteId: string | undefined
 
+  // Monotonic counter bumped whenever activeRoute.waypoints is (re)assigned.
+  // The worker keys its routeRemaining cache on this number so the cache
+  // survives the structured clone that worker.postMessage performs on every
+  // tick — array references would not.
+  let waypointsVersion = 0
+
   let metaSent = false
 
   // ******** REQUIRED PLUGIN DEFINITION *******
@@ -316,6 +322,7 @@ module.exports = (server: CourseComputerApp): Plugin => {
         activeRouteId = ci.activeRoute.href.split('/').slice(-1)[0]
         const waypoints = await getWaypoints(activeRouteId)
         srcPaths['activeRoute'].waypoints = waypoints
+        srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
       }
     }
     server.debug(`[srcPaths]: ${JSON.stringify(srcPaths)}`)
@@ -336,6 +343,7 @@ module.exports = (server: CourseComputerApp): Plugin => {
       server.debug(`*** matched activeRouteId *** ${activeRouteId}`)
       const waypoints = await getWaypoints(activeRouteId as string)
       srcPaths['activeRoute'].waypoints = waypoints
+      srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
     }
   }
 
@@ -355,7 +363,8 @@ module.exports = (server: CourseComputerApp): Plugin => {
     if (value.href.includes(activeRouteId)) {
       const waypoints = await getWaypoints(activeRouteId as string)
       srcPaths['activeRoute'] = Object.assign({}, value, {
-        waypoints: waypoints
+        waypoints: waypoints,
+        waypointsVersion: ++waypointsVersion
       })
     }
     server.debug(

--- a/src/lib/delta-msg.ts
+++ b/src/lib/delta-msg.ts
@@ -1,7 +1,7 @@
 import { Path, PathValue } from '@signalk/server-api'
-import { CourseData } from '../types'
+import { CalcMethod, CourseData } from '../types'
 
-export type CalcMethod = 'GreatCircle' | 'Rhumbline'
+export type { CalcMethod }
 
 const BASE = 'navigation.course.calcValues'
 
@@ -32,10 +32,7 @@ const VALUES_LENGTH = 16
  * preserved verbatim from the original implementation to keep the delta
  * stream byte-compatible with existing subscribers.
  */
-export function buildDeltaMsg(
-  course: CourseData,
-  method: CalcMethod
-) {
+export function buildDeltaMsg(course: CourseData, method: CalcMethod) {
   const source = method === 'Rhumbline' ? course.rl : course.gc
   const values: PathValue[] = new Array(VALUES_LENGTH)
 
@@ -54,7 +51,10 @@ export function buildDeltaMsg(
     value: source.previousPoint?.distance ?? null
   }
   values[5] = { path: PATH_DISTANCE as Path, value: source.distance ?? null }
-  values[6] = { path: PATH_BEARING_TRUE as Path, value: source.bearingTrue ?? null }
+  values[6] = {
+    path: PATH_BEARING_TRUE as Path,
+    value: source.bearingTrue ?? null
+  }
   values[7] = {
     path: PATH_BEARING_MAG as Path,
     value: source.bearingMagnetic ?? null

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,17 @@ export interface SKPaths {
   [key: string]: any
 }
 
+export type CalcMethod = 'GreatCircle' | 'Rhumbline'
+
+// Worker invocation envelope. The worker only ever needs the current path
+// snapshot plus the calculation method that buildDeltaMsg will publish, so
+// we send those together to avoid keeping the worker stateful or mixing the
+// method tag into the SignalK path map.
+export interface CalcRequest {
+  paths: SKPaths
+  method: CalcMethod
+}
+
 export interface CourseData {
   gc: CourseResult
   rl: CourseResult

--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -1,17 +1,41 @@
+/**
+ * Course calculation worker.
+ *
+ * Runs in a Node worker thread. Each tick it receives the latest SignalK
+ * path snapshot plus the configured calculation method (GreatCircle or
+ * Rhumbline) and emits the corresponding `CourseData` slice the main thread
+ * needs to publish. Only the configured branch is computed; the unused
+ * branch is returned empty so existing callers can still index by `gc`/`rl`
+ * without conditional access.
+ */
+
 import { parentPort } from 'worker_threads'
-import { CourseData, SKPaths } from '../types'
+import {
+  CalcMethod,
+  CalcRequest,
+  CourseData,
+  CourseResult,
+  SKPaths
+} from '../types'
 import { LatLonSpherical as LatLon } from '../lib/geodesy/latlon-spherical.js'
+
+// Empty-result template factory. Used both for the no-active-destination
+// transition message and the early-exit path inside calcs(); centralising
+// the shape avoids drift if CourseData ever gets a new required field.
+function emptyCourseData(): CourseData {
+  return { gc: {}, rl: {}, passedPerpendicular: false }
+}
 
 let activeDest = false
 
 // process message from main thread
-parentPort?.on('message', (message: SKPaths) => {
-  if (parseSKPaths(message)) {
-    parentPort?.postMessage(calcs(message))
+parentPort?.on('message', (message: CalcRequest) => {
+  if (parseSKPaths(message.paths)) {
+    parentPort?.postMessage(calcs(message.paths, message.method))
     activeDest = true
   } else {
     if (activeDest) {
-      parentPort?.postMessage({ gc: {}, rl: {} })
+      parentPort?.postMessage(emptyCourseData())
       activeDest = false
     }
   }
@@ -42,8 +66,12 @@ function compassAngle(angle: number): number {
     : angle
 }
 
-// course calculations
-function calcs(src: SKPaths): CourseData {
+// course calculations.
+//
+// `method` selects the branch (`gc` for GreatCircle, `rl` for Rhumbline) to
+// compute. The unused branch is returned empty so existing callers can still
+// index by `gc`/`rl` without conditional access.
+export function calcs(src: SKPaths, method: CalcMethod): CourseData {
   const vesselPosition = src['navigation.position']
     ? new LatLon(
         src['navigation.position'].latitude,
@@ -63,79 +91,62 @@ function calcs(src: SKPaths): CourseData {
       )
     : null
 
-  const res: CourseData = { gc: {}, rl: {}, passedPerpendicular: false }
+  const res = emptyCourseData()
   if (!vesselPosition || !destination || !startPoint) {
     return res
   }
 
-  const xte = vesselPosition?.crossTrackDistanceTo(startPoint, destination)
+  const xte = vesselPosition.crossTrackDistanceTo(startPoint, destination)
   const magVar = src['navigation.magneticVariation'] ?? 0.0
   const vmgValue = vmg(src)
+  const rhumbLine = method === 'Rhumbline'
 
-  // GreatCircle
-  const bearingTrackTrue = toRadians(startPoint?.initialBearingTo(destination))
-  const bearingTrue = toRadians(vesselPosition?.initialBearingTo(destination))
+  const bearingTrackTrue = toRadians(
+    rhumbLine
+      ? startPoint.rhumbBearingTo(destination)
+      : startPoint.initialBearingTo(destination)
+  )
   const bearingTrackMagnetic = compassAngle(bearingTrackTrue + magVar)
+  const bearingTrue = toRadians(
+    rhumbLine
+      ? vesselPosition.rhumbBearingTo(destination)
+      : vesselPosition.initialBearingTo(destination)
+  )
   const bearingMagnetic = compassAngle(bearingTrue + magVar)
-  const gcDistance = vesselPosition?.distanceTo(destination)
-  const gcVmg = vmgValue
-  const gcVmc = vmc(src, bearingTrue, 'true') // for ETA, TTG - prefer 'true' values
-  const gcTime = timeCalcs(src, gcDistance, gcVmc as number, false)
+  const distance = rhumbLine
+    ? vesselPosition.rhumbDistanceTo(destination)
+    : vesselPosition.distanceTo(destination)
+  const vmcValue = vmc(src, bearingTrue, 'true') // for ETA, TTG - prefer 'true' values
+  const time = timeCalcs(src, distance, vmcValue as number, rhumbLine)
+  const previousPointDistance = rhumbLine
+    ? vesselPosition.rhumbDistanceTo(startPoint)
+    : vesselPosition.distanceTo(startPoint)
 
-  res.gc = {
-    calcMethod: 'GreatCircle',
-    bearingTrackTrue: bearingTrackTrue,
-    bearingTrackMagnetic: bearingTrackMagnetic,
+  const methodResult: CourseResult = {
+    calcMethod: rhumbLine ? 'Rhumbline' : 'GreatCircle',
+    bearingTrackTrue,
+    bearingTrackMagnetic,
     crossTrackError: xte,
-    distance: gcDistance,
-    bearingTrue: bearingTrue,
-    bearingMagnetic: bearingMagnetic,
-    velocityMadeGood: gcVmg,
-    velocityMadeGoodToCourse: gcVmc,
-    timeToGo: gcTime.nextPoint.ttg,
-    estimatedTimeOfArrival: gcTime.nextPoint.eta,
-    previousPoint: {
-      distance: vesselPosition?.distanceTo(startPoint)
-    },
+    distance,
+    bearingTrue,
+    bearingMagnetic,
+    velocityMadeGood: vmgValue,
+    velocityMadeGoodToCourse: vmcValue,
+    timeToGo: time.nextPoint.ttg,
+    estimatedTimeOfArrival: time.nextPoint.eta,
+    previousPoint: { distance: previousPointDistance },
     route: {
-      timeToGo: gcTime.route.ttg,
-      estimatedTimeOfArrival: gcTime.route.eta,
-      distance: gcTime.route.dtg
+      timeToGo: time.route.ttg,
+      estimatedTimeOfArrival: time.route.eta,
+      distance: time.route.dtg
     },
-    targetSpeed: targetSpeed(src, gcDistance)
+    targetSpeed: targetSpeed(src, distance, rhumbLine)
   }
 
-  // Rhumbline
-  const rlBearingTrackTrue = toRadians(startPoint?.rhumbBearingTo(destination))
-  const rlBearingTrue = toRadians(vesselPosition?.rhumbBearingTo(destination))
-  const rlBearingTrackMagnetic = compassAngle(rlBearingTrackTrue + magVar)
-  const rlBearingMagnetic = compassAngle(rlBearingTrue + magVar)
-  const rlDistance = vesselPosition?.rhumbDistanceTo(destination)
-  const rlVmg = vmgValue
-  const rlVmc = vmc(src, rlBearingTrue, 'true') // for ETA, TTG - prefer 'true' values
-  const rlTime = timeCalcs(src, rlDistance, rlVmc as number, true)
-
-  res.rl = {
-    calcMethod: 'Rhumbline',
-    bearingTrackTrue: rlBearingTrackTrue,
-    bearingTrackMagnetic: rlBearingTrackMagnetic,
-    crossTrackError: xte,
-    distance: rlDistance,
-    bearingTrue: rlBearingTrue,
-    bearingMagnetic: rlBearingMagnetic,
-    velocityMadeGood: rlVmg,
-    velocityMadeGoodToCourse: rlVmc,
-    timeToGo: rlTime.nextPoint.ttg,
-    estimatedTimeOfArrival: rlTime.nextPoint.eta,
-    previousPoint: {
-      distance: vesselPosition?.rhumbDistanceTo(startPoint)
-    },
-    route: {
-      timeToGo: rlTime.route.ttg,
-      estimatedTimeOfArrival: rlTime.route.eta,
-      distance: rlTime.route.dtg
-    },
-    targetSpeed: targetSpeed(src, rlDistance, true)
+  if (rhumbLine) {
+    res.rl = methodResult
+  } else {
+    res.gc = methodResult
   }
 
   // passed destination perpendicular

--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -8,10 +8,13 @@
  * branch is returned empty so existing callers can still index by `gc`/`rl`
  * without conditional access.
  *
- * The track bearing (previousPoint -> nextPoint) is cached across ticks
- * because it depends only on the route endpoints and magneticVariation, not
- * on vessel position. The cache is invalidated whenever any of those keys
- * change.
+ * Two caches keep the per-tick cost down on the hot path:
+ *   - track bearing (previousPoint -> nextPoint), invalidated on endpoint
+ *     or magneticVariation change;
+ *   - route remaining distance, invalidated on waypoints/pointIndex/reverse
+ *     change (keyed on a primitive version counter from the main thread,
+ *     since structured-cloned array references would not survive the
+ *     postMessage boundary).
  */
 
 import { parentPort } from 'worker_threads'
@@ -125,6 +128,24 @@ function trackBearings(
   }
   return { bearingTrackTrue, bearingTrackMagnetic }
 }
+
+// Route remaining distance cache. The total only changes when waypoints,
+// pointIndex, reverse flag, or geodesy flavour change, but the function is
+// called on every position tick.
+//
+// The cache is keyed on `waypointsVersion`, a primitive bumped by the main
+// thread whenever it (re)assigns activeRoute.waypoints. We can't use the
+// array reference itself because worker.postMessage structured-clones the
+// envelope, so the worker sees a fresh array reference every tick even when
+// the route is unchanged.
+interface RouteRemainingCache {
+  waypointsVersion: number
+  pointIndex: number
+  reverse: boolean
+  rhumbLine: boolean
+  total: number
+}
+let routeRemainingCache: RouteRemainingCache | null = null
 
 // course calculations.
 //
@@ -365,20 +386,22 @@ export function targetSpeed(
 }
 
 // total distance in meters of remaining route segments
-function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
+export function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
   if (
     src['activeRoute']?.pointIndex === null ||
     !Array.isArray(src['activeRoute']?.waypoints)
   ) {
     return 0
   }
-  if (src['activeRoute']?.waypoints.length < 2) {
+  const waypoints = src['activeRoute'].waypoints as Array<[number, number]>
+  if (waypoints.length < 2) {
     return 0
   }
 
-  let reverse = src['activeRoute']?.reverse
-  let ptIndex = src['activeRoute']?.pointIndex
-  let lastIndex = src['activeRoute']?.waypoints.length - 1
+  const reverse = !!src['activeRoute'].reverse
+  const ptIndex = src['activeRoute'].pointIndex
+  const lastIndex = waypoints.length - 1
+  const useRhumbLine = !!rhumbLine
 
   // determine segments to sum
   let fromIndex: number
@@ -397,17 +420,44 @@ function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
     toIndex = lastIndex
   }
 
-  // sum segment lengths
-  let wpts = src['activeRoute'].waypoints
+  // The main thread bumps `waypointsVersion` on every (re)assignment of
+  // activeRoute.waypoints. We need a primitive cache key here because the
+  // worker receives a freshly-cloned waypoints array on every postMessage,
+  // so reference equality would never hold across ticks.
+  const waypointsVersion = src['activeRoute'].waypointsVersion
+  const canCache = typeof waypointsVersion === 'number'
+
+  if (canCache) {
+    const cache = routeRemainingCache
+    if (
+      cache &&
+      cache.waypointsVersion === waypointsVersion &&
+      cache.pointIndex === ptIndex &&
+      cache.reverse === reverse &&
+      cache.rhumbLine === useRhumbLine
+    ) {
+      return cache.total
+    }
+  }
+
+  // Sum segment lengths. Advance a single LatLon cursor instead of allocating
+  // two LatLon objects per iteration; on a 50-waypoint route that saves ~50
+  // allocations per cache miss.
+  let pt = new LatLon(waypoints[fromIndex][1], waypoints[fromIndex][0])
   let rteLen = 0
   for (let idx = fromIndex; idx < toIndex; idx++) {
-    let pt = new LatLon(wpts[idx][1], wpts[idx][0])
-    if (rhumbLine) {
-      rteLen += pt.rhumbDistanceTo(
-        new LatLon(wpts[idx + 1][1], wpts[idx + 1][0])
-      )
-    } else {
-      rteLen += pt.distanceTo(new LatLon(wpts[idx + 1][1], wpts[idx + 1][0]))
+    const next = new LatLon(waypoints[idx + 1][1], waypoints[idx + 1][0])
+    rteLen += useRhumbLine ? pt.rhumbDistanceTo(next) : pt.distanceTo(next)
+    pt = next
+  }
+
+  if (canCache) {
+    routeRemainingCache = {
+      waypointsVersion,
+      pointIndex: ptIndex,
+      reverse,
+      rhumbLine: useRhumbLine,
+      total: rteLen
     }
   }
   return rteLen

--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -7,6 +7,11 @@
  * needs to publish. Only the configured branch is computed; the unused
  * branch is returned empty so existing callers can still index by `gc`/`rl`
  * without conditional access.
+ *
+ * The track bearing (previousPoint -> nextPoint) is cached across ticks
+ * because it depends only on the route endpoints and magneticVariation, not
+ * on vessel position. The cache is invalidated whenever any of those keys
+ * change.
  */
 
 import { parentPort } from 'worker_threads'
@@ -66,6 +71,61 @@ function compassAngle(angle: number): number {
     : angle
 }
 
+// Track bearing (previousPoint -> nextPoint) cache. The bearing depends only
+// on the route endpoints and magneticVariation, never on vessel position, so
+// it can be reused across ticks until any of those change.
+interface TrackBearingCache {
+  prevLat: number
+  prevLon: number
+  nextLat: number
+  nextLon: number
+  magVar: number
+  rhumbLine: boolean
+  bearingTrackTrue: number
+  bearingTrackMagnetic: number
+}
+let trackBearingCache: TrackBearingCache | null = null
+
+function trackBearings(
+  startPoint: LatLon,
+  destination: LatLon,
+  magVar: number,
+  rhumbLine: boolean
+): { bearingTrackTrue: number; bearingTrackMagnetic: number } {
+  const c = trackBearingCache
+  if (
+    c &&
+    c.rhumbLine === rhumbLine &&
+    c.magVar === magVar &&
+    c.prevLat === startPoint.lat &&
+    c.prevLon === startPoint.lon &&
+    c.nextLat === destination.lat &&
+    c.nextLon === destination.lon
+  ) {
+    return {
+      bearingTrackTrue: c.bearingTrackTrue,
+      bearingTrackMagnetic: c.bearingTrackMagnetic
+    }
+  }
+  const bearingTrackTrue = toRadians(
+    rhumbLine
+      ? startPoint.rhumbBearingTo(destination)
+      : startPoint.initialBearingTo(destination)
+  )
+  const bearingTrackMagnetic = compassAngle(bearingTrackTrue + magVar)
+  trackBearingCache = {
+    prevLat: startPoint.lat,
+    prevLon: startPoint.lon,
+    nextLat: destination.lat,
+    nextLon: destination.lon,
+    magVar,
+    rhumbLine,
+    bearingTrackTrue,
+    bearingTrackMagnetic
+  }
+  return { bearingTrackTrue, bearingTrackMagnetic }
+}
+
 // course calculations.
 //
 // `method` selects the branch (`gc` for GreatCircle, `rl` for Rhumbline) to
@@ -101,12 +161,12 @@ export function calcs(src: SKPaths, method: CalcMethod): CourseData {
   const vmgValue = vmg(src)
   const rhumbLine = method === 'Rhumbline'
 
-  const bearingTrackTrue = toRadians(
+  const { bearingTrackTrue, bearingTrackMagnetic } = trackBearings(
+    startPoint,
+    destination,
+    magVar,
     rhumbLine
-      ? startPoint.rhumbBearingTo(destination)
-      : startPoint.initialBearingTo(destination)
   )
-  const bearingTrackMagnetic = compassAngle(bearingTrackTrue + magVar)
   const bearingTrue = toRadians(
     rhumbLine
       ? vesselPosition.rhumbBearingTo(destination)

--- a/test/active-route.test.ts
+++ b/test/active-route.test.ts
@@ -90,7 +90,8 @@ async function startPlugin(getResourceImpl: (id: string) => Promise<any>) {
 }
 
 // Drive a navigation.position through the dispatcher so the worker mock
-// receives the current srcPaths snapshot. Returns that snapshot object.
+// receives the current srcPaths snapshot. Returns the paths object from
+// the latest posted CalcRequest envelope.
 async function snapshotSrcPaths(
   deltaCallback: DeltaCallback,
   worker: MockWorker
@@ -112,7 +113,10 @@ async function snapshotSrcPaths(
   await new Promise((r) => setTimeout(r, 0))
   const after = worker.postedMessages.length
   expect(after).toBeGreaterThan(before)
-  return worker.postedMessages[after - 1] as Record<string, any>
+  const envelope = worker.postedMessages[after - 1] as {
+    paths: Record<string, any>
+  }
+  return envelope.paths
 }
 
 describe('navigation.course.activeRoute dispatch', () => {

--- a/test/calc-result.test.ts
+++ b/test/calc-result.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+// Tests the main-thread side of the worker -> main round trip: when the
+// worker fires a `message` event with a CourseData result, calcResult must
+// drive the arrival watcher and the published delta from the configured
+// method's branch — not unconditionally from `gc`.
+
+const workerInstances: MockWorker[] = []
+
+class MockWorker {
+  public postedMessages: unknown[] = []
+  private listeners: Record<string, Array<(arg: unknown) => void>> = {}
+
+  constructor(public filename: string) {
+    workerInstances.push(this)
+  }
+
+  on(event: string, handler: (arg: unknown) => void) {
+    this.listeners[event] = this.listeners[event] || []
+    this.listeners[event].push(handler)
+    return this
+  }
+
+  removeAllListeners() {
+    this.listeners = {}
+    return this
+  }
+
+  terminate() {
+    return Promise.resolve(0)
+  }
+
+  postMessage(_msg: unknown) {}
+
+  unref() {}
+
+  // Test-only: invokes registered listeners synchronously, simulating the
+  // worker firing back into the main thread.
+  fire(event: string, arg: unknown) {
+    const handlers = this.listeners[event] ?? []
+    for (const h of handlers) h(arg)
+  }
+}
+
+vi.mock('worker_threads', () => ({ Worker: MockWorker }))
+vi.mock('express', () => ({}))
+
+beforeEach(() => {
+  workerInstances.length = 0
+  vi.resetModules()
+})
+
+async function startPlugin(method: 'GreatCircle' | 'Rhumbline') {
+  const pluginModule = (await import('../src/index.ts')) as any
+  const factory = (pluginModule.default ?? pluginModule) as (server: any) => {
+    start: (options: any) => void
+    stop: () => void
+  }
+
+  const server = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    setPluginStatus: vi.fn(),
+    setPluginError: vi.fn(),
+    handleMessage: vi.fn(),
+    getSelfPath: vi.fn(() => null),
+    getCourse: vi.fn(() => Promise.resolve(null)),
+    get: vi.fn(),
+    subscriptionmanager: {
+      subscribe: vi.fn((_sub: unknown, unsubscribes: Array<() => void>) => {
+        unsubscribes.push(() => {})
+      })
+    },
+    resourcesApi: { getResource: vi.fn(() => Promise.resolve(null)) }
+  }
+
+  const plugin = factory(server)
+  plugin.start({ notifications: { sound: false }, calculations: { method } })
+  return {
+    server,
+    worker: workerInstances[workerInstances.length - 1],
+    stop: () => plugin.stop()
+  }
+}
+
+function distanceFromDelta(handleMessageMock: any): number | null {
+  // The plugin emits a v2 delta whose `values` array is the fixed-shape
+  // output of buildDeltaMsg. The distance entry is at index 5.
+  for (const call of handleMessageMock.mock.calls) {
+    const msg = call[1]
+    const values = msg?.updates?.[0]?.values
+    if (!Array.isArray(values)) continue
+    for (const v of values) {
+      if (v.path === 'navigation.course.calcValues.distance') {
+        return v.value
+      }
+    }
+  }
+  return null
+}
+
+describe('calcResult selects the configured method branch', () => {
+  it('publishes Rhumbline distance when configured for Rhumbline', async () => {
+    const { server, worker, stop } = await startPlugin('Rhumbline')
+
+    worker.fire('message', {
+      gc: {},
+      rl: { distance: 1234, calcMethod: 'Rhumbline' },
+      passedPerpendicular: false
+    })
+
+    expect(distanceFromDelta(server.handleMessage)).toBe(1234)
+    stop()
+  })
+
+  it('publishes GreatCircle distance when configured for GreatCircle', async () => {
+    const { server, worker, stop } = await startPlugin('GreatCircle')
+
+    worker.fire('message', {
+      gc: { distance: 5678, calcMethod: 'GreatCircle' },
+      rl: {},
+      passedPerpendicular: false
+    })
+
+    expect(distanceFromDelta(server.handleMessage)).toBe(5678)
+    stop()
+  })
+})

--- a/test/course-calcs.test.ts
+++ b/test/course-calcs.test.ts
@@ -199,3 +199,191 @@ describe('track bearing cache (task 4)', () => {
     expect(result.gc).toEqual({})
   })
 })
+
+describe('routeRemaining cache and cursor reuse (tasks 5, 6)', () => {
+  // A 4-waypoint route along the equator: 1deg + 1deg + 1deg = 3deg, which
+  // the stub maps to 3 * 1000 = 3000 m.
+  //
+  // `waypointsVersion` is the cache key that survives the structured clone
+  // performed by worker.postMessage. The main thread bumps it whenever
+  // activeRoute.waypoints is reassigned; tests pass it explicitly to model
+  // that behaviour.
+  function routeSrc(waypointsVersion: number = 1): Record<string, any> {
+    return {
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [3, 0]
+        ] as Array<[number, number]>,
+        pointIndex: 0,
+        reverse: false,
+        waypointsVersion
+      }
+    }
+  }
+
+  it('returns the great-circle total of remaining segments', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+    expect(routeRemaining(routeSrc(), false)).toBe(3000)
+  })
+
+  it('returns the rhumb-line total of remaining segments', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+    // Stub adds 0.5 per segment to differentiate from gc; 3 segments -> +1.5.
+    expect(routeRemaining(routeSrc(), true)).toBe(3001.5)
+  })
+
+  it('serves repeated calls from cache without re-summing segments', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    const src = routeSrc()
+    const first = routeRemaining(src, false)
+
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'distanceTo')
+    const second = routeRemaining(src, false)
+    expect(second).toBe(first)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('runs exactly one distance call per segment (no double allocation)', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    const distSpy = vi.spyOn(LatLonSpherical.prototype, 'distanceTo')
+    routeRemaining(routeSrc(), false)
+    // 4 waypoints, fromIndex 0, toIndex 3 -> 3 segments -> 3 distance calls.
+    // Cursor reuse keeps this at one call per segment instead of paying for
+    // two LatLon constructions per iteration.
+    expect(distSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('invalidates when waypointsVersion bumps (route content changed)', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    routeRemaining(routeSrc(1), false)
+
+    const replaced = routeSrc(2) // version bumped: route content has changed
+    replaced.activeRoute.waypoints[3] = [4, 0] // total now 4 segments worth
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'distanceTo')
+    const total = routeRemaining(replaced, false)
+
+    expect(spy).toHaveBeenCalled()
+    expect(total).toBe(4000)
+  })
+
+  it('hits cache after structuredClone (across worker postMessage)', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    // Models the production flow: main thread builds srcPaths once, posts to
+    // the worker every tick, Node structured-clones the envelope. The cache
+    // must hit on the cloned object as long as waypointsVersion is unchanged.
+    const tick1 = routeSrc(7)
+    const first = routeRemaining(tick1, false)
+
+    const tick2 = structuredClone(tick1)
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'distanceTo')
+    const second = routeRemaining(tick2, false)
+
+    expect(second).toBe(first)
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('invalidates when pointIndex advances', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    const src = routeSrc()
+    const fromStart = routeRemaining(src, false)
+
+    src.activeRoute.pointIndex = 2
+    const fromMid = routeRemaining(src, false)
+
+    expect(fromStart).toBe(3000)
+    // Only the last segment remains: 1 * 1000 = 1000 m.
+    expect(fromMid).toBe(1000)
+  })
+
+  it('invalidates when reverse flag changes', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    const src = routeSrc()
+    src.activeRoute.pointIndex = 1
+    routeRemaining(src, false)
+
+    // Spy after the cache is warm; flipping `reverse` must force a recompute
+    // even though waypointsVersion / pointIndex / rhumbLine are unchanged.
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'distanceTo')
+    src.activeRoute.reverse = true
+    routeRemaining(src, false)
+
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('returns 0 in reverse when pointIndex equals lastIndex', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+    const src = routeSrc()
+    src.activeRoute.pointIndex = 3 // = lastIndex
+    src.activeRoute.reverse = true
+    // Reverse early-return: fromIndex 0, toIndex = lastIndex - lastIndex = 0.
+    expect(routeRemaining(src, false)).toBe(0)
+  })
+
+  it('invalidates when geodesy flavour changes', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+
+    routeRemaining(routeSrc(), false)
+
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'rhumbDistanceTo')
+    const rhumbTotal = routeRemaining(routeSrc(), true)
+    expect(spy).toHaveBeenCalled()
+    expect(rhumbTotal).toBe(3001.5)
+  })
+
+  it('returns 0 when fewer than two waypoints remain', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+    const src = {
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0]
+        ],
+        pointIndex: 1,
+        reverse: false
+      }
+    }
+    expect(routeRemaining(src, false)).toBe(0)
+  })
+
+  it('returns 0 when pointIndex is null', async () => {
+    const { routeRemaining } = (await import('../src/worker/course')) as any
+    const src = {
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0]
+        ],
+        pointIndex: null,
+        reverse: false
+      }
+    }
+    expect(routeRemaining(src, false)).toBe(0)
+  })
+})

--- a/test/course-calcs.test.ts
+++ b/test/course-calcs.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+// LatLon stub. Methods return deterministic values derived from the points'
+// coordinates so tests can predict output and assert on call counts.
+//
+// distance(a, b)        = hypot(dLat, dLon) * 1000   (m)
+// rhumbDistance(a, b)   = distance(a, b) + 0.5       (so gc and rl are
+//                                                     distinguishable but
+//                                                     close in magnitude)
+// initialBearing(a, b)  = ((b.lon - a.lon) * 90 + 360) mod 360  (deg)
+// rhumbBearing(a, b)    = initialBearing(a, b) + 1   (deg)
+class StubLatLon {
+  constructor(public lat: number, public lon: number) {}
+  distanceTo(other: StubLatLon): number {
+    const dLat = other.lat - this.lat
+    const dLon = other.lon - this.lon
+    return Math.hypot(dLat, dLon) * 1000
+  }
+  rhumbDistanceTo(other: StubLatLon): number {
+    return this.distanceTo(other) + 0.5
+  }
+  initialBearingTo(other: StubLatLon): number {
+    return ((other.lon - this.lon) * 90 + 360) % 360
+  }
+  rhumbBearingTo(other: StubLatLon): number {
+    return (this.initialBearingTo(other) + 1) % 360
+  }
+  crossTrackDistanceTo(_a: StubLatLon, _b: StubLatLon): number {
+    return 0
+  }
+}
+
+vi.mock('../src/lib/geodesy/latlon-spherical.js', () => ({
+  LatLonSpherical: StubLatLon
+}))
+
+beforeEach(() => {
+  // Reset the module registry between tests so state introduced by the
+  // module under test starts clean and prototype spies are torn down.
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+function srcWithFix(opts?: {
+  magVar?: number
+  next?: { latitude: number; longitude: number }
+}): Record<string, any> {
+  return {
+    'navigation.position': { latitude: 0, longitude: 0 },
+    'navigation.course.previousPoint': {
+      position: { latitude: 0, longitude: 0 }
+    },
+    'navigation.course.nextPoint': {
+      position: opts?.next ?? { latitude: 0, longitude: 1 }
+    },
+    'navigation.magneticVariation': opts?.magVar ?? 0,
+    'navigation.courseOverGroundTrue': Math.PI / 2,
+    'navigation.speedOverGround': 5,
+    'environment.wind.angleTrueGround': 0
+  }
+}
+
+describe('calcs computes only the configured method (task 3)', () => {
+  it('populates only `gc` for GreatCircle and leaves `rl` empty', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const result = calcs(srcWithFix(), 'GreatCircle')
+
+    expect(result.gc.calcMethod).toBe('GreatCircle')
+    expect(typeof result.gc.distance).toBe('number')
+    expect(result.rl).toEqual({})
+  })
+
+  it('populates only `rl` for Rhumbline and leaves `gc` empty', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const result = calcs(srcWithFix(), 'Rhumbline')
+
+    expect(result.rl.calcMethod).toBe('Rhumbline')
+    expect(typeof result.rl.distance).toBe('number')
+    // The stubbed rhumb distance differs from the great-circle distance by 0.5
+    // so we can be certain the rhumb branch was taken.
+    expect(result.rl.distance).toBeCloseTo(1000.5, 5)
+    expect(result.gc).toEqual({})
+  })
+
+  // The guard at the top of calcs() is `!vesselPosition || !destination ||
+  // !startPoint`. Each missing input must independently short-circuit to the
+  // empty-result shape; a refactor that drops one branch should be caught here.
+  it('returns empty branches when navigation.position is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    delete src['navigation.position']
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+
+  it('returns empty branches when nextPoint is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    delete src['navigation.course.nextPoint']
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+
+  it('returns empty branches when previousPoint position is missing', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+    const src = srcWithFix()
+    src['navigation.course.previousPoint'] = {} // present but no .position
+    expect(calcs(src, 'GreatCircle')).toEqual({
+      gc: {},
+      rl: {},
+      passedPerpendicular: false
+    })
+  })
+})

--- a/test/course-calcs.test.ts
+++ b/test/course-calcs.test.ts
@@ -118,3 +118,84 @@ describe('calcs computes only the configured method (task 3)', () => {
     })
   })
 })
+
+describe('track bearing cache (task 4)', () => {
+  it('skips the prev->next bearing call on a cached tick', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { calcs } = (await import('../src/worker/course')) as any
+
+    calcs(srcWithFix(), 'GreatCircle')
+
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'initialBearingTo')
+    calcs(srcWithFix(), 'GreatCircle')
+
+    // Cache warm: bearingTrue (1) + passedPerpendicular (2) = 3.
+    // The track bearing (previousPoint -> nextPoint) is served from cache.
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it('recomputes the track bearing when nextPoint changes', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { calcs } = (await import('../src/worker/course')) as any
+
+    calcs(srcWithFix(), 'GreatCircle')
+
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'initialBearingTo')
+    // Change latitude only — keeps stub bearings (lon-driven) unchanged so
+    // the downstream timeCalcs math stays well-defined, while the cache key
+    // (nextLat) still differs and forces a recompute.
+    calcs(srcWithFix({ next: { latitude: 0.5, longitude: 1 } }), 'GreatCircle')
+
+    // Cache miss: track (1) + bearingTrue (1) + passedPerpendicular (2) = 4.
+    expect(spy).toHaveBeenCalledTimes(4)
+  })
+
+  it('recomputes the track bearing when previousPoint changes', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { calcs } = (await import('../src/worker/course')) as any
+
+    calcs(srcWithFix(), 'GreatCircle')
+
+    const spy = vi.spyOn(LatLonSpherical.prototype, 'initialBearingTo')
+    // Shift previousPoint latitude. The cache key (prevLat) differs so the
+    // track bearing must be recomputed even though nextPoint is unchanged.
+    const moved = srcWithFix()
+    moved['navigation.course.previousPoint'].position.latitude = 0.5
+    calcs(moved, 'GreatCircle')
+
+    expect(spy).toHaveBeenCalledTimes(4)
+  })
+
+  it('recomputes the magnetic track bearing when magneticVariation changes', async () => {
+    const { calcs } = (await import('../src/worker/course')) as any
+
+    const a = calcs(srcWithFix({ magVar: 0 }), 'GreatCircle')
+    const b = calcs(srcWithFix({ magVar: 0.1 }), 'GreatCircle')
+
+    expect(b.gc.bearingTrackTrue).toBe(a.gc.bearingTrackTrue)
+    expect(b.gc.bearingTrackMagnetic).not.toBe(a.gc.bearingTrackMagnetic)
+  })
+
+  it('recomputes when switching method (gc <-> rl)', async () => {
+    const { LatLonSpherical } = (await import(
+      '../src/lib/geodesy/latlon-spherical.js'
+    )) as any
+    const { calcs } = (await import('../src/worker/course')) as any
+
+    calcs(srcWithFix(), 'GreatCircle')
+
+    const rhumbSpy = vi.spyOn(LatLonSpherical.prototype, 'rhumbBearingTo')
+    const result = calcs(srcWithFix(), 'Rhumbline')
+
+    // Switching method invalidates the track bearing cache so the rhumb
+    // bearing has to be computed: rhumbBearingTo for both track and bearing.
+    expect(rhumbSpy).toHaveBeenCalledTimes(2)
+    expect(result.gc).toEqual({})
+  })
+})

--- a/test/delta-handler.test.ts
+++ b/test/delta-handler.test.ts
@@ -128,8 +128,15 @@ describe('delta handler dispatch', () => {
     })
 
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
-    expect(msg['navigation.position']).toEqual({ latitude: 10, longitude: 20 })
+    const msg = worker.postedMessages[0] as {
+      paths: Record<string, any>
+      method: string
+    }
+    expect(msg.method).toBe('GreatCircle')
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 10,
+      longitude: 20
+    })
 
     stop()
   })
@@ -202,11 +209,14 @@ describe('delta handler dispatch', () => {
 
     // Exactly one postMessage: the one triggered by navigation.position.
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
+    const msg = worker.postedMessages[0] as { paths: Record<string, any> }
     // All three values should be present in srcPaths by the time calc() runs.
-    expect(msg['navigation.speedOverGround']).toBe(4.2)
-    expect(msg['navigation.position']).toEqual({ latitude: 1, longitude: 2 })
-    expect(msg['navigation.headingTrue']).toBe(1.57)
+    expect(msg.paths['navigation.speedOverGround']).toBe(4.2)
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 1,
+      longitude: 2
+    })
+    expect(msg.paths['navigation.headingTrue']).toBe(1.57)
     stop()
   })
 
@@ -246,9 +256,12 @@ describe('delta handler dispatch', () => {
     })
 
     expect(worker.postedMessages.length).toBe(1)
-    const msg = worker.postedMessages[0] as Record<string, any>
-    expect(msg['navigation.speedOverGround']).toBe(3.1)
-    expect(msg['navigation.position']).toEqual({ latitude: 5, longitude: 6 })
+    const msg = worker.postedMessages[0] as { paths: Record<string, any> }
+    expect(msg.paths['navigation.speedOverGround']).toBe(3.1)
+    expect(msg.paths['navigation.position']).toEqual({
+      latitude: 5,
+      longitude: 6
+    })
     stop()
   })
 })


### PR DESCRIPTION
## Summary

Caches the total remaining route distance across position ticks (task 5) and reduces per-iteration allocations in the summation loop (task 6).

The cache is keyed on a monotonic \`waypointsVersion\` integer rather than the waypoints array reference. \`worker.postMessage\` structured-clones its envelope every tick, so the worker would otherwise see a freshly allocated waypoints array each time and the cache would never hit. The main thread bumps the counter whenever it (re)assigns \`activeRoute.waypoints\` (in \`getPaths\`, \`handleRouteUpdate\`, and \`handleActiveRoute\`).

The summation loop now advances a single \`LatLon\` cursor instead of constructing two new \`LatLon\` objects per iteration — about a 50% allocation reduction on the cold-cache path for a long route.

Stacks on #16 and #17. Merge those first.

Addresses tasks 5 and 6 of #9.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 55 pass (was 43)
- [x] \`npm run lint\` clean
- [x] Cache survives \`structuredClone\` (covered by a dedicated test that mirrors the postMessage boundary)
- [ ] Soak under a real position feed at 1-2 Hz with an active 10-50 waypoint route to confirm \`distanceTo\`/\`rhumbDistanceTo\` is no longer hit per tick when the route is steady.