### PR TITLE
perf: cache routeRemaining and reuse the LatLon cursor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,12 @@ module.exports = (server: CourseComputerApp): Plugin => {
   let courseCalcs: CourseData
   let activeRouteId: string | undefined
 
+  // Monotonic counter bumped whenever activeRoute.waypoints is (re)assigned.
+  // The worker keys its routeRemaining cache on this number so the cache
+  // survives the structured clone that worker.postMessage performs on every
+  // tick — array references would not.
+  let waypointsVersion = 0
+
   let metaSent = false
 
   // ******** REQUIRED PLUGIN DEFINITION *******
@@ -310,6 +316,7 @@ module.exports = (server: CourseComputerApp): Plugin => {
         activeRouteId = ci.activeRoute.href.split('/').slice(-1)[0] ?? ''
         const waypoints = await getWaypoints(activeRouteId)
         srcPaths['activeRoute'].waypoints = waypoints
+        srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
       }
     }
     server.debug(`[srcPaths]: ${JSON.stringify(srcPaths)}`)
@@ -330,6 +337,7 @@ module.exports = (server: CourseComputerApp): Plugin => {
       server.debug(`*** matched activeRouteId *** ${activeRouteId}`)
       const waypoints = await getWaypoints(activeRouteId as string)
       srcPaths['activeRoute'].waypoints = waypoints
+      srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
     }
   }
 
@@ -349,7 +357,8 @@ module.exports = (server: CourseComputerApp): Plugin => {
     if (value.href.includes(activeRouteId)) {
       const waypoints = await getWaypoints(activeRouteId as string)
       srcPaths['activeRoute'] = Object.assign({}, value, {
-        waypoints: waypoints
+        waypoints: waypoints,
+        waypointsVersion: ++waypointsVersion
       })
     }
     server.debug(

--- a/src/worker/course.ts
+++ b/src/worker/course.ts
@@ -293,21 +293,42 @@ export function targetSpeed(
   return distance / tDiffSec
 }
 
+// Route remaining distance cache. The total only changes when waypoints,
+// pointIndex, or reverse flag change, but the function is called four times
+// per tick (gc/rl × timeCalcs/targetSpeed). Both flavours share the same
+// key inputs and are computed together in one cursor pass on miss.
+//
+// The cache is keyed on `waypointsVersion`, a primitive bumped by the main
+// thread whenever it (re)assigns activeRoute.waypoints. We can't use the
+// array reference itself because worker.postMessage structured-clones the
+// envelope, so the worker sees a fresh array reference every tick even when
+// the route is unchanged.
+interface RouteRemainingCache {
+  waypointsVersion: number
+  pointIndex: number
+  reverse: boolean
+  totalGc: number
+  totalRl: number
+}
+let routeRemainingCache: RouteRemainingCache | null = null
+
 // total distance in meters of remaining route segments
-function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
+export function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
   if (
     src['activeRoute']?.pointIndex === null ||
     !Array.isArray(src['activeRoute']?.waypoints)
   ) {
     return 0
   }
-  if (src['activeRoute']?.waypoints.length < 2) {
+  const waypoints = src['activeRoute'].waypoints as Array<[number, number]>
+  if (waypoints.length < 2) {
     return 0
   }
 
-  let reverse = src['activeRoute']?.reverse
-  let ptIndex = src['activeRoute']?.pointIndex
-  let lastIndex = src['activeRoute']?.waypoints.length - 1
+  const reverse = !!src['activeRoute'].reverse
+  const ptIndex = src['activeRoute'].pointIndex
+  const lastIndex = waypoints.length - 1
+  const useRhumbLine = !!rhumbLine
 
   // determine segments to sum
   let fromIndex: number
@@ -326,20 +347,50 @@ function routeRemaining(src: SKPaths, rhumbLine?: boolean): number {
     toIndex = lastIndex
   }
 
-  // sum segment lengths
-  let wpts = src['activeRoute'].waypoints
-  let rteLen = 0
-  for (let idx = fromIndex; idx < toIndex; idx++) {
-    let pt = new LatLon(wpts[idx][1], wpts[idx][0])
-    if (rhumbLine) {
-      rteLen += pt.rhumbDistanceTo(
-        new LatLon(wpts[idx + 1][1], wpts[idx + 1][0])
-      )
-    } else {
-      rteLen += pt.distanceTo(new LatLon(wpts[idx + 1][1], wpts[idx + 1][0]))
+  // The main thread bumps `waypointsVersion` on every (re)assignment of
+  // activeRoute.waypoints. We need a primitive cache key here because the
+  // worker receives a freshly-cloned waypoints array on every postMessage,
+  // so reference equality would never hold across ticks.
+  const waypointsVersion = src['activeRoute'].waypointsVersion
+  const canCache = typeof waypointsVersion === 'number'
+
+  if (canCache) {
+    const cache = routeRemainingCache
+    if (
+      cache &&
+      cache.waypointsVersion === waypointsVersion &&
+      cache.pointIndex === ptIndex &&
+      cache.reverse === reverse
+    ) {
+      return useRhumbLine ? cache.totalRl : cache.totalGc
     }
   }
-  return rteLen
+
+  // Sum segment lengths for both flavours in a single pass. Advance one
+  // LatLon cursor instead of allocating two LatLon objects per iteration;
+  // on a 50-waypoint route that is ~50 fewer allocations per cache miss.
+  const fromWp = waypoints[fromIndex]!
+  let pt = new LatLon(fromWp[1], fromWp[0])
+  let totalGc = 0
+  let totalRl = 0
+  for (let idx = fromIndex; idx < toIndex; idx++) {
+    const wp = waypoints[idx + 1]!
+    const next = new LatLon(wp[1], wp[0])
+    totalGc += pt.distanceTo(next)
+    totalRl += pt.rhumbDistanceTo(next)
+    pt = next
+  }
+
+  if (canCache) {
+    routeRemainingCache = {
+      waypointsVersion,
+      pointIndex: ptIndex,
+      reverse,
+      totalGc,
+      totalRl
+    }
+  }
+  return useRhumbLine ? totalRl : totalGc
 }
 
 // return true if vessel is past perpendicular of destination

--- a/test/route-remaining.test.ts
+++ b/test/route-remaining.test.ts
@@ -1,0 +1,221 @@
+import { expect } from 'chai'
+import { mockModule, resetModuleCache } from './helpers'
+
+// LatLon stub. Methods return deterministic values derived from the points'
+// coordinates so tests can predict output and assert on call counts.
+//
+// distance(a, b)        = hypot(dLat, dLon) * 1000   (m)
+// rhumbDistance(a, b)   = distance(a, b) + 0.5
+//
+// `callCounts` is reset between tests to assert how often distanceTo /
+// rhumbDistanceTo are called per cache hit / miss.
+const callCounts = {
+  distanceTo: 0,
+  rhumbDistanceTo: 0
+}
+
+class StubLatLon {
+  constructor(
+    public lat: number,
+    public lon: number
+  ) {}
+  distanceTo(other: StubLatLon): number {
+    callCounts.distanceTo++
+    const dLat = other.lat - this.lat
+    const dLon = other.lon - this.lon
+    return Math.hypot(dLat, dLon) * 1000
+  }
+  rhumbDistanceTo(other: StubLatLon): number {
+    callCounts.rhumbDistanceTo++
+    // Inlined rather than calling distanceTo so the count for the latter
+    // does not include internal calls.
+    const dLat = other.lat - this.lat
+    const dLon = other.lon - this.lon
+    return Math.hypot(dLat, dLon) * 1000 + 0.5
+  }
+  initialBearingTo(other: StubLatLon): number {
+    return ((other.lon - this.lon) * 90 + 360) % 360
+  }
+  rhumbBearingTo(other: StubLatLon): number {
+    return ((((other.lon - this.lon) * 90 + 360) % 360) + 1) % 360
+  }
+  crossTrackDistanceTo(_a: StubLatLon, _b: StubLatLon): number {
+    return 0
+  }
+}
+
+let restoreLatLon: () => void = () => {}
+
+function loadRouteRemaining(): (src: any, useRhumbLine: boolean) => number {
+  resetModuleCache('../src/worker/course')
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const mod = require('../src/worker/course') as any
+  return mod.routeRemaining
+}
+
+// A 4-waypoint route along the equator: 1deg + 1deg + 1deg = 3deg, which
+// the stub maps to 3 * 1000 = 3000 m.
+//
+// `waypointsVersion` is the cache key that survives the structured clone
+// performed by worker.postMessage. The main thread bumps it whenever
+// activeRoute.waypoints is reassigned; tests pass it explicitly to model
+// that behaviour.
+function routeSrc(waypointsVersion: number = 1): Record<string, any> {
+  return {
+    activeRoute: {
+      waypoints: [
+        [0, 0],
+        [1, 0],
+        [2, 0],
+        [3, 0]
+      ] as Array<[number, number]>,
+      pointIndex: 0,
+      reverse: false,
+      waypointsVersion
+    }
+  }
+}
+
+describe('routeRemaining cache and cursor reuse', () => {
+  let routeRemaining: (src: any, useRhumbLine: boolean) => number
+
+  before(() => {
+    restoreLatLon = mockModule('../src/lib/geodesy/latlon-spherical.js', {
+      LatLonSpherical: StubLatLon
+    })
+  })
+
+  after(() => {
+    restoreLatLon()
+    resetModuleCache('../src/worker/course')
+  })
+
+  beforeEach(() => {
+    routeRemaining = loadRouteRemaining()
+    callCounts.distanceTo = 0
+    callCounts.rhumbDistanceTo = 0
+  })
+
+  it('returns the great-circle total of remaining segments', () => {
+    expect(routeRemaining(routeSrc(), false)).to.equal(3000)
+  })
+
+  it('returns the rhumb-line total of remaining segments', () => {
+    // Stub adds 0.5 per segment to differentiate from gc; 3 segments -> +1.5.
+    expect(routeRemaining(routeSrc(), true)).to.equal(3001.5)
+  })
+
+  it('serves both flavours from cache after a single computation pass', () => {
+    const src = routeSrc()
+    const gcFirst = routeRemaining(src, false)
+
+    // After the first call, both gc and rl totals are cached. Subsequent
+    // calls in either flavour must not recompute.
+    callCounts.distanceTo = 0
+    callCounts.rhumbDistanceTo = 0
+    const gcSecond = routeRemaining(src, false)
+    const rlAfterGc = routeRemaining(src, true)
+
+    expect(gcSecond).to.equal(gcFirst)
+    expect(rlAfterGc).to.equal(3001.5)
+    expect(callCounts.distanceTo).to.equal(0)
+    expect(callCounts.rhumbDistanceTo).to.equal(0)
+  })
+
+  it('runs exactly one distance call per segment per flavour (no double allocation)', () => {
+    routeRemaining(routeSrc(), false)
+    // 4 waypoints, fromIndex 0, toIndex 3 -> 3 segments. With cursor reuse
+    // and both-flavours-in-one-pass: 3 distanceTo + 3 rhumbDistanceTo.
+    expect(callCounts.distanceTo).to.equal(3)
+    expect(callCounts.rhumbDistanceTo).to.equal(3)
+  })
+
+  it('invalidates when waypointsVersion bumps (route content changed)', () => {
+    routeRemaining(routeSrc(1), false)
+
+    const replaced = routeSrc(2) // version bumped: route content has changed
+    replaced.activeRoute.waypoints[3] = [4, 0] // total now 4 segments worth
+    callCounts.distanceTo = 0
+    const total = routeRemaining(replaced, false)
+
+    expect(callCounts.distanceTo).to.be.greaterThan(0)
+    expect(total).to.equal(4000)
+  })
+
+  it('hits cache after structuredClone (across worker postMessage)', () => {
+    // Models the production flow: main thread builds srcPaths once, posts to
+    // the worker every tick, Node structured-clones the envelope. The cache
+    // must hit on the cloned object as long as waypointsVersion is unchanged.
+    const tick1 = routeSrc(7)
+    const first = routeRemaining(tick1, false)
+
+    const tick2 = structuredClone(tick1)
+    callCounts.distanceTo = 0
+    const second = routeRemaining(tick2, false)
+
+    expect(second).to.equal(first)
+    expect(callCounts.distanceTo).to.equal(0)
+  })
+
+  it('invalidates when pointIndex advances', () => {
+    const src = routeSrc()
+    const fromStart = routeRemaining(src, false)
+
+    src.activeRoute.pointIndex = 2
+    const fromMid = routeRemaining(src, false)
+
+    expect(fromStart).to.equal(3000)
+    // Only the last segment remains: 1 * 1000 = 1000 m.
+    expect(fromMid).to.equal(1000)
+  })
+
+  it('invalidates when reverse flag changes', () => {
+    const src = routeSrc()
+    src.activeRoute.pointIndex = 1
+    routeRemaining(src, false)
+
+    // Reset counter; flipping `reverse` must force a recompute even though
+    // waypointsVersion / pointIndex are unchanged.
+    callCounts.distanceTo = 0
+    src.activeRoute.reverse = true
+    routeRemaining(src, false)
+
+    expect(callCounts.distanceTo).to.be.greaterThan(0)
+  })
+
+  it('returns 0 in reverse when pointIndex equals lastIndex', () => {
+    const src = routeSrc()
+    src.activeRoute.pointIndex = 3 // = lastIndex
+    src.activeRoute.reverse = true
+    // Reverse early-return: fromIndex 0, toIndex = lastIndex - lastIndex = 0.
+    expect(routeRemaining(src, false)).to.equal(0)
+  })
+
+  it('returns 0 when fewer than two waypoints remain', () => {
+    const src = {
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0]
+        ],
+        pointIndex: 1,
+        reverse: false
+      }
+    }
+    expect(routeRemaining(src, false)).to.equal(0)
+  })
+
+  it('returns 0 when pointIndex is null', () => {
+    const src = {
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0]
+        ],
+        pointIndex: null,
+        reverse: false
+      }
+    }
+    expect(routeRemaining(src, false)).to.equal(0)
+  })
+})


### PR DESCRIPTION
## Summary

Caches the total remaining route distance across position ticks (task 5) and reduces per-iteration allocations in the summation loop (task 6).

The cache is keyed on a monotonic `waypointsVersion` integer rather than the waypoints array reference. `worker.postMessage` structured-clones its envelope every tick, so the worker would otherwise see a freshly allocated waypoints array each time and the cache would never hit. The main thread bumps the counter whenever it (re)assigns `activeRoute.waypoints` (in `getPaths`, `handleRouteUpdate`, and `handleActiveRoute`).

Both great-circle and rhumb-line totals are computed in a single cursor-reused pass on cache miss and stored together; every tick is either four cache hits (gc/rl × timeCalcs/targetSpeed) or one pass through the waypoints. The summation loop advances a single `LatLon` cursor instead of constructing two new objects per iteration — about a 50% allocation reduction on the cold-cache path.

Addresses tasks 5 and 6 of #9. Independent of master (parallel to #19).

## Test plan

- [x] `npm run typecheck` / `npm test` / `npm run prettier:check` clean
- [x] 41 tests pass (was 31 — added 10 cache-behaviour regression tests, including one that exercises the `structuredClone` boundary)