### PR TITLE
fix: replace stored activeRoute when a different route becomes active

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -350,17 +350,19 @@ module.exports = (server: CourseComputerApp): Plugin => {
       activeRouteId = undefined
       return
     }
-    if (!activeRouteId) {
-      activeRouteId = value.href.split('/').slice(-1)[0]
-    }
 
-    if (value.href.includes(activeRouteId)) {
-      const waypoints = await getWaypoints(activeRouteId as string)
-      srcPaths['activeRoute'] = Object.assign({}, value, {
-        waypoints: waypoints,
-        waypointsVersion: ++waypointsVersion
-      })
-    }
+    // Always derive activeRouteId from the incoming value so a switch from
+    // one route to another takes effect. The previous code only assigned
+    // activeRouteId when it was unset and then guarded the waypoint fetch
+    // on `value.href.includes(activeRouteId)`, which silently rejected the
+    // new value and left srcPaths pointing at the old route.
+    const newId = value.href.split('/').slice(-1)[0] ?? ''
+    activeRouteId = newId
+    const waypoints = await getWaypoints(newId)
+    srcPaths['activeRoute'] = Object.assign({}, value, {
+      waypoints: waypoints,
+      waypointsVersion: ++waypointsVersion
+    })
     server.debug(
       `*** activeRoute *** ${JSON.stringify(srcPaths['activeRoute'])}`
     )

--- a/test/active-route.test.ts
+++ b/test/active-route.test.ts
@@ -31,7 +31,7 @@ class MockWorker {
 
 type DeltaCallback = (delta: unknown) => void
 
-function startPlugin(getResourceImpl: (id: string) => Promise<any>) {
+function startPlugin(getResourceImpl: (...args: any[]) => Promise<any>) {
   // Replace Worker on the singleton worker_threads module so the plugin's
   // `new Worker(...)` call constructs MockWorker instead. Re-applied per
   // start because sibling test files may have installed their own
@@ -178,6 +178,73 @@ describe('navigation.course.activeRoute dispatch', () => {
 
     const snapshot = await snapshotSrcPaths(deltaCallback, worker)
     expect(snapshot.activeRoute).to.be.null
+    stop()
+  })
+
+  // Regression: switching from one route to another must replace the stored
+  // activeRoute. Previously activeRouteId was only set when unset, and the
+  // `value.href.includes(activeRouteId)` guard rejected any incoming value
+  // whose href did not contain the original route id.
+  it('replaces stored activeRoute when a different route becomes active', async () => {
+    const waypointsA = [
+      [10, 20],
+      [11, 21]
+    ]
+    const waypointsB = [
+      [30, 40],
+      [31, 41],
+      [32, 42]
+    ]
+    const { deltaCallback, worker, server, stop } = startPlugin(
+      async (_resType: string, id: string) => {
+        if (id === 'route-a') {
+          return { feature: { geometry: { coordinates: waypointsA } } }
+        }
+        if (id === 'route-b') {
+          return { feature: { geometry: { coordinates: waypointsB } } }
+        }
+        return null
+      }
+    )
+
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-a', name: 'A' }
+            }
+          ]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    const afterA = await snapshotSrcPaths(deltaCallback, worker)
+    expect(afterA.activeRoute.href).to.equal('/resources/routes/route-a')
+    expect(afterA.activeRoute.waypoints).to.deep.equal(waypointsA)
+
+    // Switch to route B. Without the fix, srcPaths.activeRoute remains A.
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-b', name: 'B' }
+            }
+          ]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    const afterB = await snapshotSrcPaths(deltaCallback, worker)
+
+    expect(afterB.activeRoute.href).to.equal('/resources/routes/route-b')
+    expect(afterB.activeRoute.name).to.equal('B')
+    expect(afterB.activeRoute.waypoints).to.deep.equal(waypointsB)
+    expect(server.resourcesApi.getResource.calledWith('routes', 'route-b')).to
+      .be.true
     stop()
   })
 })


### PR DESCRIPTION
## Summary

`handleActiveRoute` set `activeRouteId` only when it was previously unset, then guarded the waypoint fetch on `value.href.includes(activeRouteId)`. When the user switched from one active route to another, that guard rejected the incoming value: `srcPaths['activeRoute']` kept pointing at the old route and downstream calculations (distance to next waypoint, ETA, route remaining) ran against stale data until the plugin restarted.

Always derive `activeRouteId` from the incoming value, refetch waypoints, and overwrite `srcPaths['activeRoute']`. The null-clearing branch is unchanged.

Found while reviewing #19 / #20 — pre-existing bug, not introduced by those PRs, but the cache in #20 would otherwise lock the stale total under a higher `waypointsVersion`.

## Test plan

- [x] `npm run typecheck` / `npm test` / `npm run prettier:check` clean
- [x] 32 tests pass (was 31 — new regression test activates route A then route B and asserts `srcPaths.activeRoute` follows the switch)