### PR TITLE
fix: drop stale getWaypoints results from out-of-order async fetches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -350,17 +350,19 @@ module.exports = (server: CourseComputerApp): Plugin => {
       activeRouteId = undefined
       return
     }
-    if (!activeRouteId) {
-      activeRouteId = value.href.split('/').slice(-1)[0]
-    }
 
-    if (value.href.includes(activeRouteId)) {
-      const waypoints = await getWaypoints(activeRouteId as string)
-      srcPaths['activeRoute'] = Object.assign({}, value, {
-        waypoints: waypoints,
-        waypointsVersion: ++waypointsVersion
-      })
-    }
+    // Always derive activeRouteId from the incoming value so a switch from
+    // one route to another takes effect. The previous code only assigned
+    // activeRouteId when it was unset and then guarded the waypoint fetch
+    // on `value.href.includes(activeRouteId)`, which silently rejected the
+    // new value and left srcPaths pointing at the old route.
+    const newId = value.href.split('/').slice(-1)[0] ?? ''
+    activeRouteId = newId
+    const waypoints = await getWaypoints(newId)
+    srcPaths['activeRoute'] = Object.assign({}, value, {
+      waypoints: waypoints,
+      waypointsVersion: ++waypointsVersion
+    })
     server.debug(
       `*** activeRoute *** ${JSON.stringify(srcPaths['activeRoute'])}`
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,12 @@ module.exports = (server: CourseComputerApp): Plugin => {
   // tick — array references would not.
   let waypointsVersion = 0
 
+  // Monotonic token bumped before every getWaypoints() fetch and on
+  // activeRoute clear. The handler that initiated a fetch only commits its
+  // result if its token is still the latest one, so concurrent or
+  // out-of-order fetches cannot let an older resource overwrite a newer one.
+  let routeFetchToken = 0
+
   let metaSent = false
 
   // ******** REQUIRED PLUGIN DEFINITION *******
@@ -314,7 +320,13 @@ module.exports = (server: CourseComputerApp): Plugin => {
         // non-empty string, but `noUncheckedIndexedAccess` types it as
         // `string | undefined`. Empty fallback is unreachable in practice.
         activeRouteId = ci.activeRoute.href.split('/').slice(-1)[0] ?? ''
+        const myToken = ++routeFetchToken
         const waypoints = await getWaypoints(activeRouteId)
+        // initSubscriptions does not await getPaths, so a delta fired during
+        // startup can complete its fetch first; drop our result if so.
+        if (myToken !== routeFetchToken) {
+          return
+        }
         srcPaths['activeRoute'].waypoints = waypoints
         srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
       }
@@ -335,7 +347,13 @@ module.exports = (server: CourseComputerApp): Plugin => {
     server.debug(`*** handleRouteUpdate *** ${JSON.stringify(msg)}`)
     if (msg.path.endsWith(activeRouteId as string)) {
       server.debug(`*** matched activeRouteId *** ${activeRouteId}`)
+      const myToken = ++routeFetchToken
       const waypoints = await getWaypoints(activeRouteId as string)
+      // A newer fetch (another resources.routes update or a route switch)
+      // has been issued in the meantime; drop our stale result.
+      if (myToken !== routeFetchToken) {
+        return
+      }
       srcPaths['activeRoute'].waypoints = waypoints
       srcPaths['activeRoute'].waypointsVersion = ++waypointsVersion
     }
@@ -346,19 +364,23 @@ module.exports = (server: CourseComputerApp): Plugin => {
     server.debug(`*** handleActiveRoute *** ${JSON.stringify(value)}`)
 
     if (!value) {
+      // Bump the token so any in-flight fetch from a previous activation is
+      // ignored when it eventually resolves.
+      routeFetchToken++
       srcPaths['activeRoute'] = null
       activeRouteId = undefined
       return
     }
 
     // Always derive activeRouteId from the incoming value so a switch from
-    // one route to another takes effect. The previous code only assigned
-    // activeRouteId when it was unset and then guarded the waypoint fetch
-    // on `value.href.includes(activeRouteId)`, which silently rejected the
-    // new value and left srcPaths pointing at the old route.
+    // one route to another takes effect.
     const newId = value.href.split('/').slice(-1)[0] ?? ''
     activeRouteId = newId
+    const myToken = ++routeFetchToken
     const waypoints = await getWaypoints(newId)
+    if (myToken !== routeFetchToken) {
+      return
+    }
     srcPaths['activeRoute'] = Object.assign({}, value, {
       waypoints: waypoints,
       waypointsVersion: ++waypointsVersion

--- a/test/active-route.test.ts
+++ b/test/active-route.test.ts
@@ -31,7 +31,7 @@ class MockWorker {
 
 type DeltaCallback = (delta: unknown) => void
 
-function startPlugin(getResourceImpl: (id: string) => Promise<any>) {
+function startPlugin(getResourceImpl: (...args: any[]) => Promise<any>) {
   // Replace Worker on the singleton worker_threads module so the plugin's
   // `new Worker(...)` call constructs MockWorker instead. Re-applied per
   // start because sibling test files may have installed their own
@@ -178,6 +178,73 @@ describe('navigation.course.activeRoute dispatch', () => {
 
     const snapshot = await snapshotSrcPaths(deltaCallback, worker)
     expect(snapshot.activeRoute).to.be.null
+    stop()
+  })
+
+  // Regression: switching from one route to another must replace the stored
+  // activeRoute. Previously activeRouteId was only set when unset, and the
+  // `value.href.includes(activeRouteId)` guard rejected any incoming value
+  // whose href did not contain the original route id.
+  it('replaces stored activeRoute when a different route becomes active', async () => {
+    const waypointsA = [
+      [10, 20],
+      [11, 21]
+    ]
+    const waypointsB = [
+      [30, 40],
+      [31, 41],
+      [32, 42]
+    ]
+    const { deltaCallback, worker, server, stop } = startPlugin(
+      async (_resType: string, id: string) => {
+        if (id === 'route-a') {
+          return { feature: { geometry: { coordinates: waypointsA } } }
+        }
+        if (id === 'route-b') {
+          return { feature: { geometry: { coordinates: waypointsB } } }
+        }
+        return null
+      }
+    )
+
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-a', name: 'A' }
+            }
+          ]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    const afterA = await snapshotSrcPaths(deltaCallback, worker)
+    expect(afterA.activeRoute.href).to.equal('/resources/routes/route-a')
+    expect(afterA.activeRoute.waypoints).to.deep.equal(waypointsA)
+
+    // Switch to route B. Without the fix, srcPaths.activeRoute remains A.
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-b', name: 'B' }
+            }
+          ]
+        }
+      ]
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    const afterB = await snapshotSrcPaths(deltaCallback, worker)
+
+    expect(afterB.activeRoute.href).to.equal('/resources/routes/route-b')
+    expect(afterB.activeRoute.name).to.equal('B')
+    expect(afterB.activeRoute.waypoints).to.deep.equal(waypointsB)
+    expect(server.resourcesApi.getResource.calledWith('routes', 'route-b')).to
+      .be.true
     stop()
   })
 })

--- a/test/active-route.test.ts
+++ b/test/active-route.test.ts
@@ -181,6 +181,74 @@ describe('navigation.course.activeRoute dispatch', () => {
     stop()
   })
 
+  // Regression: out-of-order resolution of getWaypoints() between two
+  // route-activation events must not overwrite the newer route with the
+  // older one's late result. Previously every fetch unconditionally
+  // committed, so a slow A followed by a quick B left srcPaths pointing at
+  // B briefly and then A once A finally resolved.
+  it('drops a stale getWaypoints result when a newer route fetch has started', async () => {
+    const waypointsA = [
+      [10, 20],
+      [11, 21]
+    ]
+    const waypointsB = [
+      [30, 40],
+      [31, 41],
+      [32, 42]
+    ]
+    let resolveA: (value: any) => void = () => {}
+    const aPromise = new Promise<any>((r) => {
+      resolveA = r
+    })
+    const { deltaCallback, worker, stop } = startPlugin(
+      async (_resType: string, id: string) => {
+        if (id === 'route-a') return aPromise
+        if (id === 'route-b') {
+          return { feature: { geometry: { coordinates: waypointsB } } }
+        }
+        return null
+      }
+    )
+
+    // Activate route A — the fetch is pending until we explicitly resolve it.
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-a', name: 'A' }
+            }
+          ]
+        }
+      ]
+    })
+    // Activate route B before A's fetch resolves; B's fetch resolves promptly.
+    deltaCallback({
+      updates: [
+        {
+          values: [
+            {
+              path: 'navigation.course.activeRoute',
+              value: { href: '/resources/routes/route-b', name: 'B' }
+            }
+          ]
+        }
+      ]
+    })
+    // Let B's microtasks settle so its result lands first.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Now A finally resolves — its result must NOT overwrite B.
+    resolveA({ feature: { geometry: { coordinates: waypointsA } } })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const snapshot = await snapshotSrcPaths(deltaCallback, worker)
+    expect(snapshot.activeRoute.href).to.equal('/resources/routes/route-b')
+    expect(snapshot.activeRoute.waypoints).to.deep.equal(waypointsB)
+    stop()
+  })
+
   // Regression: switching from one route to another must replace the stored
   // activeRoute. Previously activeRouteId was only set when unset, and the
   // `value.href.includes(activeRouteId)` guard rejected any incoming value


### PR DESCRIPTION
## Stacking

This PR is **stacked on #22**. Merge #22 first; this PR's diff against master shows both commits.

## Summary

`handleActiveRoute`, `handleRouteUpdate`, and `getPaths` all `await getWaypoints()` and then unconditionally commit the result to `srcPaths`. If two route updates fire close together (a route switch followed by a resource update, or two activations in quick succession) and the second resource fetch resolves before the first, the older waypoints land in `srcPaths` after the newer ones, leaving stale state until the next event.

Bump a `routeFetchToken` before every fetch and only commit if our token is still the latest. `handleActiveRoute(null)` bumps the token too so any in-flight fetch from a previous activation is ignored when it resolves.

## Test plan

- [x] `npm run typecheck` / `npm test` / `npm run prettier:check` clean
- [x] 33 tests pass after #22 (new regression test controls the resolution order of two `getWaypoints` calls and asserts that the late-arriving stale result does not overwrite the newer one)