### PR TITLE
fix(test): import passedPerpendicular from src/, drop double-dot in filename

### DIFF
--- a/test/passedPerpendicular.test.ts
+++ b/test/passedPerpendicular.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import { LatLonSpherical } from '../src/lib/geodesy/latlon-spherical'
-import { passedPerpendicular } from '../plugin/worker/course'
+import { passedPerpendicular } from '../src/worker/course'
 
 describe('Passed Perpendicular', () => {
   it('(+ive diff) should return FALSE', () => {


### PR DESCRIPTION
The test file added in be122af imports from `../plugin/worker/course`, which only exists after `npm run build`. CI runs `typecheck` before `build`, so every open PR fails on:

\`\`\`
error TS2307: Cannot find module '../plugin/worker/course'
\`\`\`

Two trivial fixes:

- Switch the import to `../src/worker/course` (the function is already exported there).
- Rename `passedPerpendicular.test..ts` -> `passedPerpendicular.test.ts` (drop the stray double dot).

Blocks #19, #20, #22, #23, #24 — all of them currently fail typecheck because of this file.

## Test plan

- [x] `rm -rf plugin && npm run typecheck` clean (matches CI's pre-build state)
- [x] `npm test` 39 passing