### PR TITLE
chore: drop Node 20/22, support Node 24/26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [24.x, 26.x]
 
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/chai": "^5.2.3",
         "@types/express": "^5.0.6",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.9.2",
         "c8": "^11.0.0",
         "chai": "^6.2.2",
         "mitata": "^1.0.34",
@@ -29,8 +29,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
-        "node": ">=20.10"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1783,9 +1782,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+      "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "//": "Floor at 20.10 to support Venus CerboGX firmware (currently Node 20.18.2). Bump back to >=22 once Cerbo ships a newer Node.",
-    "node": ">=20.10"
+    "node": ">=24"
   },
   "files": [
     "plugin",
@@ -75,7 +74,7 @@
     "@types/chai": "^5.2.3",
     "@types/express": "^5.0.6",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.9.2",
     "c8": "^11.0.0",
     "chai": "^6.2.2",
     "mitata": "^1.0.34",


### PR DESCRIPTION
> **Hold for Venus OS.** This is going to land as soon as Venus OS supports Node v24 (see [Discord context](https://discord.com/channels/1170433917761892493/1512189657666949441/1512439811477078048)).

Drop Node 20 and 22, support Node 24 and 26.

- `engines.node`: `>=20.10` → `>=24` (drops the Cerbo special-case; the Cerbo runtime will catch up, and `>=24` unlocks Node 24+ APIs).
- CI matrix: `[20.x, 22.x, 24.x]` → `[24.x, 26.x]`. Coverage stays on Node 24 (LTS); 26.x is the regression-catcher.
- `@types/node`: bumped to `^25.9.2` (latest published; DefinitelyTyped hasn't released `@types/node@26` yet — Node 26 only landed a few days ago. Bump again once DT publishes).