### PR TITLE
fix(course): decouple route DTG from vmc gate

### DIFF
--- a/src/lib/course.ts
+++ b/src/lib/course.ts
@@ -197,13 +197,20 @@ export function timeCalcs(
     route: { ttg: null, eta: null, dtg: null }
   }
 
-  if (
-    typeof distance !== 'number' ||
-    !Number.isFinite(distance) ||
-    typeof vmc !== 'number' ||
-    !Number.isFinite(vmc) ||
-    vmc <= 0
-  ) {
+  if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+    return result
+  }
+
+  // Route-remaining distance is pure geometry, independent of velocity: it
+  // must not blink to null just because the vessel isn't currently closing
+  // on the next waypoint (e.g. right after rounding a mark, or while
+  // tacking upwind — both routine sail-trim states with vmc <= 0).
+  const routeDistance = isRoute
+    ? distance + routeRemaining(src, rhumbLine)
+    : null
+  result.route.dtg = routeDistance
+
+  if (typeof vmc !== 'number' || !Number.isFinite(vmc) || vmc <= 0) {
     return result
   }
 
@@ -217,13 +224,11 @@ export function timeCalcs(
   result.nextPoint.ttg = nextTtgMsec / 1000
   result.nextPoint.eta = new Date(nextEtaMsec).toISOString()
 
-  if (isRoute) {
-    const rteDistance = distance + routeRemaining(src, rhumbLine)
-    const routeTtgMsec = Math.floor((rteDistance / vmc) * 1000)
+  if (routeDistance !== null) {
+    const routeTtgMsec = Math.floor((routeDistance / vmc) * 1000)
     const routeEtaMsec = dateMsec + routeTtgMsec
     result.route.ttg = routeTtgMsec / 1000
     result.route.eta = new Date(routeEtaMsec).toISOString()
-    result.route.dtg = rteDistance
   }
   return result
 }

--- a/test/course-defensive.test.ts
+++ b/test/course-defensive.test.ts
@@ -17,7 +17,7 @@ const courseModule = require('../src/lib/course') as {
     passedPerp: boolean
   ) => {
     nextPoint: { ttg: number | null; eta: string | null }
-    route: { ttg: number | null; eta: string | null }
+    route: { ttg: number | null; eta: string | null; dtg: number | null }
   }
   targetSpeed: (src: any, distance: number) => number | null
 }
@@ -108,6 +108,33 @@ describe('course calculations defensive guards', () => {
 
     expect(result.nextPoint.ttg).to.be.null
     expect(result.nextPoint.eta).to.be.null
+  })
+
+  it('timeCalcs still reports route.dtg when vmc is non-positive (DTG is pure geometry)', () => {
+    // The vessel has just rounded a mark: vmc is momentarily negative, but
+    // the remaining route distance has not changed and must still be
+    // reported. TTG/ETA remain null — they are undefined without a
+    // positive closing speed.
+    const src = {
+      'navigation.datetime': '2020-01-01T00:00:00.000Z',
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0],
+          [2, 0]
+        ],
+        pointIndex: 0,
+        reverse: false
+      }
+    }
+    const result = timeCalcs(src, 500, -1, false)
+
+    expect(result.nextPoint.ttg).to.be.null
+    expect(result.nextPoint.eta).to.be.null
+    expect(result.route.ttg).to.be.null
+    expect(result.route.eta).to.be.null
+    expect(result.route.dtg).to.be.a('number')
+    expect(result.route.dtg).to.be.greaterThan(500)
   })
 
   it('targetSpeed returns null for invalid targetArrivalTime', () => {


### PR DESCRIPTION
## Motivation

`timeCalcs()` returns early whenever `vmc` (velocity made good to
course — the SOG component along the bearing to the next waypoint) is
`<= 0`. That early return also skipped `route.dtg` (distance to the
end of the active route), even though remaining route distance is
pure geometry and has nothing to do with the vessel's current closing
speed.

`vmc <= 0` is not an edge case — it's routine: right after rounding a
mark (bearing swings behind the boat before COG catches up), or while
tacking/reaching away from the rhumb line upwind. Every consumer of
`navigation.course.calcValues.route.distance` (chartplotter DTG
widgets, etc.) sees that value flicker to `null` in exactly those
moments, even though the boat obviously hasn't teleported and the
route hasn't changed.

## Approach

Move the `route.dtg` computation ahead of the `vmc` validity check, so
it's computed whenever an active route is present — independent of
`vmc`. `route.ttg` / `route.eta` (and the next-point `ttg`/`eta`)
remain gated behind `vmc > 0`, since a time-to-arrival is genuinely
undefined without a positive closing rate.

## Test plan

- [x] `npm run prettier:check`
- [x] `npm run typecheck`
- [x] `npm test` (149 passing, +1 new)
- [x] Added a regression test: `route.dtg` stays a finite number when
      `vmc` is negative on an active route, while `ttg`/`eta` stay
      `null`.

Related to a second PR that additionally populates `route.*` for
ad-hoc (single-point) destinations, not just activated routes — kept
separate per "one logical change per PR".