### PR TITLE
feat(course): fill route.* for ad-hoc destinations

### DIFF
--- a/src/lib/course.ts
+++ b/src/lib/course.ts
@@ -197,13 +197,20 @@ export function timeCalcs(
     route: { ttg: null, eta: null, dtg: null }
   }
 
-  if (
-    typeof distance !== 'number' ||
-    !Number.isFinite(distance) ||
-    typeof vmc !== 'number' ||
-    !Number.isFinite(vmc) ||
-    vmc <= 0
-  ) {
+  if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+    return result
+  }
+
+  // Route-remaining distance is pure geometry, independent of velocity: it
+  // must not blink to null just because the vessel isn't currently closing
+  // on the next waypoint (e.g. right after rounding a mark, or while
+  // tacking upwind — both routine sail-trim states with vmc <= 0).
+  const routeDistance = isRoute
+    ? distance + routeRemaining(src, rhumbLine)
+    : null
+  result.route.dtg = routeDistance
+
+  if (typeof vmc !== 'number' || !Number.isFinite(vmc) || vmc <= 0) {
     return result
   }
 
@@ -217,13 +224,11 @@ export function timeCalcs(
   result.nextPoint.ttg = nextTtgMsec / 1000
   result.nextPoint.eta = new Date(nextEtaMsec).toISOString()
 
-  if (isRoute) {
-    const rteDistance = distance + routeRemaining(src, rhumbLine)
-    const routeTtgMsec = Math.floor((rteDistance / vmc) * 1000)
+  if (routeDistance !== null) {
+    const routeTtgMsec = Math.floor((routeDistance / vmc) * 1000)
     const routeEtaMsec = dateMsec + routeTtgMsec
     result.route.ttg = routeTtgMsec / 1000
     result.route.eta = new Date(routeEtaMsec).toISOString()
-    result.route.dtg = rteDistance
   }
   return result
 }

--- a/src/lib/course.ts
+++ b/src/lib/course.ts
@@ -188,10 +188,6 @@ export function timeCalcs(
   vmc: number,
   rhumbLine: boolean
 ): CourseTimes {
-  const isRoute =
-    Array.isArray(src['activeRoute']?.waypoints) &&
-    src['activeRoute']?.waypoints.length !== 0
-
   const result: CourseTimes = {
     nextPoint: { ttg: null, eta: null },
     route: { ttg: null, eta: null, dtg: null }
@@ -201,13 +197,11 @@ export function timeCalcs(
     return result
   }
 
-  // Route-remaining distance is pure geometry, independent of velocity: it
-  // must not blink to null just because the vessel isn't currently closing
-  // on the next waypoint (e.g. right after rounding a mark, or while
-  // tacking upwind — both routine sail-trim states with vmc <= 0).
-  const routeDistance = isRoute
-    ? distance + routeRemaining(src, rhumbLine)
-    : null
+  // routeRemaining() is 0 without an active multi-waypoint route, so this
+  // degrades to the next-point distance for an ad-hoc (single-point)
+  // destination: route.* is meaningful whenever a destination exists at
+  // all, not only when a Route resource has been activated.
+  const routeDistance = distance + routeRemaining(src, rhumbLine)
   result.route.dtg = routeDistance
 
   if (typeof vmc !== 'number' || !Number.isFinite(vmc) || vmc <= 0) {
@@ -224,12 +218,10 @@ export function timeCalcs(
   result.nextPoint.ttg = nextTtgMsec / 1000
   result.nextPoint.eta = new Date(nextEtaMsec).toISOString()
 
-  if (routeDistance !== null) {
-    const routeTtgMsec = Math.floor((routeDistance / vmc) * 1000)
-    const routeEtaMsec = dateMsec + routeTtgMsec
-    result.route.ttg = routeTtgMsec / 1000
-    result.route.eta = new Date(routeEtaMsec).toISOString()
-  }
+  const routeTtgMsec = Math.floor((routeDistance / vmc) * 1000)
+  const routeEtaMsec = dateMsec + routeTtgMsec
+  result.route.ttg = routeTtgMsec / 1000
+  result.route.eta = new Date(routeEtaMsec).toISOString()
   return result
 }
 

--- a/test/course-defensive.test.ts
+++ b/test/course-defensive.test.ts
@@ -151,15 +151,42 @@ describe('timeCalcs / targetSpeed positive paths', () => {
   // Pins the arithmetic so the Date-allocation refactor can't change
   // observable outputs (TTG seconds, ETA ISO string, targetSpeed).
 
-  it('timeCalcs derives TTG and ETA from an ISO datetime', () => {
-    // 1000 m at 10 m/s = 100 s -> ETA = base + 100 s
+  it('timeCalcs derives TTG and ETA from an ISO datetime, mirrored onto route.* without an active route', () => {
+    // 1000 m at 10 m/s = 100 s -> ETA = base + 100 s. No activeRoute is set,
+    // so this is an ad-hoc (single-point) destination: route.* must still
+    // populate, mirroring nextPoint, since routeRemaining() is 0.
     const src = { 'navigation.datetime': '2020-01-01T00:00:00.000Z' }
     const result = timeCalcs(src, 1000, 10, false)
 
     expect(result.nextPoint.ttg).to.equal(100)
     expect(result.nextPoint.eta).to.equal('2020-01-01T00:01:40.000Z')
-    expect(result.route.ttg).to.be.null
-    expect(result.route.eta).to.be.null
+    expect(result.route.ttg).to.equal(100)
+    expect(result.route.eta).to.equal('2020-01-01T00:01:40.000Z')
+  })
+
+  it('timeCalcs adds remaining route segments on top of nextPoint distance for a real route', () => {
+    // nextPoint leg: 1000 m at 10 m/s = 100 s. Route continues for two more
+    // 1-degree-of-longitude-on-the-equator legs (~111,195 m each via
+    // routeRemaining's great-circle math), so route.dtg/ttg must exceed
+    // nextPoint's, not just mirror it as in the ad-hoc case above.
+    const src = {
+      'navigation.datetime': '2020-01-01T00:00:00.000Z',
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0],
+          [2, 0]
+        ],
+        pointIndex: 0,
+        reverse: false
+      }
+    }
+    const result = timeCalcs(src, 1000, 10, false)
+
+    expect(result.nextPoint.ttg).to.equal(100)
+    expect(result.route.ttg).to.be.a('number')
+    expect(result.route.ttg as number).to.be.greaterThan(100)
+    expect(result.route.eta).to.not.equal(result.nextPoint.eta)
   })
 
   it('timeCalcs accepts numeric epoch-ms datetime (legacy tolerance)', () => {

--- a/test/course-defensive.test.ts
+++ b/test/course-defensive.test.ts
@@ -17,7 +17,7 @@ const courseModule = require('../src/lib/course') as {
     passedPerp: boolean
   ) => {
     nextPoint: { ttg: number | null; eta: string | null }
-    route: { ttg: number | null; eta: string | null }
+    route: { ttg: number | null; eta: string | null; dtg: number | null }
   }
   targetSpeed: (src: any, distance: number) => number | null
 }
@@ -108,6 +108,33 @@ describe('course calculations defensive guards', () => {
 
     expect(result.nextPoint.ttg).to.be.null
     expect(result.nextPoint.eta).to.be.null
+  })
+
+  it('timeCalcs still reports route.dtg when vmc is non-positive (DTG is pure geometry)', () => {
+    // The vessel has just rounded a mark: vmc is momentarily negative, but
+    // the remaining route distance has not changed and must still be
+    // reported. TTG/ETA remain null — they are undefined without a
+    // positive closing speed.
+    const src = {
+      'navigation.datetime': '2020-01-01T00:00:00.000Z',
+      activeRoute: {
+        waypoints: [
+          [0, 0],
+          [1, 0],
+          [2, 0]
+        ],
+        pointIndex: 0,
+        reverse: false
+      }
+    }
+    const result = timeCalcs(src, 500, -1, false)
+
+    expect(result.nextPoint.ttg).to.be.null
+    expect(result.nextPoint.eta).to.be.null
+    expect(result.route.ttg).to.be.null
+    expect(result.route.eta).to.be.null
+    expect(result.route.dtg).to.be.a('number')
+    expect(result.route.dtg).to.be.greaterThan(500)
   })
 
   it('targetSpeed returns null for invalid targetArrivalTime', () => {


### PR DESCRIPTION
**Stacked on #50** — this branch is based on `fix/route-dtg-independent-of-vmc`, so the diff currently includes that commit too. Once #50 merges, rebasing this branch onto `master` will leave only the second commit and this PR's diff will shrink to just this change.

## Motivation

`route.dtg` / `route.ttg` / `route.eta` only populated when
`navigation.course.activeRoute` had a non-empty `waypoints` array —
i.e. only when a Route *resource* was activated
(`PUT .../course/activeRoute`). A plain ad-hoc destination
(`PUT .../course/destination`, no Route resource involved) never sets
`activeRoute`, so any consumer bound to the `calcValues.route.*` paths
(rather than the plain next-point paths) got nothing at all while
navigating to a bare point — even though distance/TTG/ETA to that
point are exactly as meaningful as they are for a route leg.

## Approach

`routeRemaining()` already returns `0` when there's no active
multi-waypoint route. That means `route.*` can be computed
unconditionally: `distance + routeRemaining(...)` degrades to the
next-point distance for an ad-hoc destination, and adds the remaining
route segments on top for a real route — the same formula serves both
cases. Drops the now-redundant `isRoute` gate.

## Test plan

- [x] `npm run prettier:check`
- [x] `npm run typecheck`
- [x] `npm test` (150 passing)
- [x] Updated the existing "derives TTG and ETA from an ISO datetime"
      test, which had asserted `route.ttg`/`route.eta` stay `null`
      without an active route — that was the bug, now fixed; it
      asserts they mirror `nextPoint` instead.
- [x] Added a regression test proving a real multi-waypoint route
      still adds the remaining segments on top of the next-point leg
      (`route.ttg` > `nextPoint.ttg`), so the fix doesn't collapse
      route semantics into next-point semantics.